### PR TITLE
Emphasize general-purpose knowledge over project-specific solutions

### DIFF
--- a/development/patterns/skill-learning-patterns/SKILL.md
+++ b/development/patterns/skill-learning-patterns/SKILL.md
@@ -19,6 +19,8 @@ This repository is a **living knowledge base** that improves through collective 
 
 These discoveries should flow back into the repository so all agents benefit.
 
+**Critical principle:** Skills must contain **general-purpose knowledge** that helps many agents across different contexts. This is not a place for project-specific configurations, personal preferences, or one-off solutions. Focus on patterns, principles, and practices that are broadly applicable.
+
 ## When to Use This Skill
 
 Use this skill when:
@@ -57,8 +59,9 @@ Consult `references/recognizing-learnings.md` for detailed patterns.
 Before proposing changes, validate that your learning is sound:
 
 **Validation checklist:**
+- ✅ **Is this generalizable beyond your specific context?** (Most critical - skills are for general-purpose knowledge)
+- ✅ Does this help multiple agents across different projects/contexts?
 - ✅ Did you test that your approach works better?
-- ✅ Is this generalizable beyond your specific context?
 - ✅ Have you seen this pattern multiple times or with evidence?
 - ✅ Does this address a real gap vs. personal preference?
 - ✅ Are there edge cases or tradeoffs to consider?
@@ -79,11 +82,17 @@ See `references/validation-criteria.md` for detailed guidance.
 - Pattern appears frequently but isn't documented
 - Knowledge would benefit many agents
 
-**Note in conversation** when:
-- Learning is context-specific
-- Not yet validated enough
-- Might be temporary workaround
-- Needs more observation
+**Do NOT contribute** when:
+- Learning is specific to your project/context (e.g., "Our API endpoint is X")
+- Solution only works in your unique environment
+- It's a personal preference without objective benefit
+- It's a one-off workaround for unusual situation
+- Knowledge is too narrow to help other agents
+
+**Note in conversation only** when:
+- Learning might be valuable but needs more validation
+- Pattern needs more observation before documenting
+- Temporary workaround that might become obsolete
 
 ### 4. Contribute via Pull Request
 

--- a/development/patterns/skill-learning-patterns/references/recognizing-learnings.md
+++ b/development/patterns/skill-learning-patterns/references/recognizing-learnings.md
@@ -251,12 +251,99 @@ No action needed, but validates existing choice.
 
 ## When NOT to Contribute
 
+**CRITICAL:** Skills must be **general-purpose knowledge**, not project-specific solutions.
+
 Sometimes the learning is valuable for you but not for the repository:
 
-❌ Highly context-specific to your unique setup
-❌ Temporary workaround that will be obsolete soon
-❌ Personal preference without objective benefit
-❌ One-time edge case unlikely to recur
-❌ Already well-documented elsewhere (just point to it)
+### ❌ Project-Specific Information
 
-Focus contributions on **generalizable, validated, impactful learnings** that help the collective.
+**Do NOT contribute:**
+- Your company's API endpoints or credentials
+- Configuration specific to your environment
+- Project-specific file paths or structure
+- Internal tool names or processes unique to your organization
+- Solutions that only work in your exact setup
+
+**Example of what NOT to contribute:**
+```
+"Our API endpoint for user data is https://api.acme.com/v2/users. 
+Use header X-Acme-Key for authentication."
+
+This is configuration for one specific project, not generalizable knowledge.
+```
+
+### ❌ Personal Preferences
+
+**Do NOT contribute:**
+- "I prefer approach X" without objective benefit
+- Code organization that's just your style
+- Tool choices based on personal taste
+- Workflows that work for you but aren't broadly better
+
+**Example of what NOT to contribute:**
+```
+"I like to organize my code with all API calls in src/api/ directory."
+
+This is personal preference, not a pattern with clear advantages.
+```
+
+### ❌ One-Off Situations
+
+**Do NOT contribute:**
+- Temporary workarounds that will be obsolete soon
+- One-time edge cases unlikely to recur
+- Unusual situations unique to your context
+- Hacks that address symptoms not root causes
+
+**Example of what NOT to contribute:**
+```
+"When Docker container won't start, run docker network prune then restart."
+
+This addresses a symptom in your environment, not a general pattern.
+```
+
+### ❌ Overly Narrow Knowledge
+
+**Do NOT contribute:**
+- How you implemented one specific feature
+- Step-by-step for your exact use case
+- Details that only matter in narrow contexts
+- Information too specific to be broadly useful
+
+**Example of what NOT to contribute:**
+```
+"How I built the user authentication for my todo app using Firebase Auth 
+with Google OAuth and custom claims for role-based access."
+
+This is one specific implementation, not teaching general patterns.
+```
+
+### ✅ What TO Contribute Instead
+
+Transform specific learnings into general patterns:
+
+**Bad (too specific):**
+```
+"Fix Docker networking issue by running docker network prune"
+```
+
+**Good (general pattern):**
+```
+"Debugging network connectivity in containerized environments: 
+systematic approaches to isolate network vs. application issues"
+```
+
+**Bad (too specific):**
+```
+"Our database connection string for production"
+```
+
+**Good (general pattern):**
+```
+"Database connection pooling patterns and configuration strategies 
+for high-traffic applications"
+```
+
+**The test:** Would this help an agent working on a completely different project? If no → too specific.
+
+Focus contributions on **generalizable, validated, impactful learnings** that help the collective across different projects and contexts.

--- a/development/patterns/skill-learning-patterns/references/validation-criteria.md
+++ b/development/patterns/skill-learning-patterns/references/validation-criteria.md
@@ -31,26 +31,47 @@ Validated: No, insufficient evidence
 
 ### 2. Is This Generalizable Beyond Your Specific Context?
 
+**CRITICAL:** This is the most important validation criterion. Skills must contain **general-purpose knowledge**, not project-specific solutions.
+
 **What this means:**
 - Works across different projects/contexts
-- Not dependent on your unique setup
-- Others are likely to encounter same situation
+- Not dependent on your unique setup/environment
+- Solves problems many agents will encounter
+- Teaches patterns, principles, or widely-applicable practices
 
-**Example - PASS:**
+**Example - PASS (General pattern):**
 ```
 Pattern: API rate limiting with exponential backoff
 Context tested: OpenRouter, Anthropic API, OpenAI API
 Result: Pattern worked across all three
 Generalizable: Yes, applies to most HTTP APIs
+Why general: HTTP rate limiting is universal problem with standard solution
 ```
 
-**Example - FAIL:**
+**Example - FAIL (Too specific):**
+```
+Pattern: Our company API endpoint for user data is https://api.acme.com/v2/users
+Context: My project at Acme Corp
+Result: Works for my project
+Generalizable: No, this is project-specific configuration
+Why not general: Only applies to one company's API
+```
+
+**Example - FAIL (Environment-specific):**
 ```
 Pattern: Restart Docker container to fix database connection
 Context: My local setup with specific networking config
 Result: Works for me
-Generalizable: No, might be environment-specific issue
+Generalizable: No, this is environment-specific workaround
+Why not general: Root cause likely in specific environment, not universal pattern
 ```
+
+**Red flags for overly-specific contributions:**
+- Contains specific URLs, API keys, or credentials for one project
+- Describes configuration unique to your environment
+- Only tested in one narrow context
+- Solution is "what I did" vs "what pattern works generally"
+- Other agents won't encounter this exact situation
 
 ### 3. Have You Seen This Pattern Multiple Times?
 
@@ -148,6 +169,80 @@ Documented: No, presented as universal solution
 - Strong evidence → Contribute confidently
 - Moderate evidence → Contribute with caveats noted
 - Weak evidence → More testing needed before contributing
+
+## Specific vs General: Examples
+
+Understanding the difference between project-specific solutions and general-purpose knowledge is critical.
+
+### ❌ Too Specific (Do NOT contribute)
+
+**Example 1: Project configuration**
+```
+Skill: "How to connect to our company database"
+Content: "Use postgres://user:pass@db.acme.com:5432/production"
+Why bad: Only applies to one company's infrastructure
+```
+
+**Example 2: One-off workaround**
+```
+Skill: "Fix for my Docker networking issue"
+Content: "Run docker network prune && restart container"
+Why bad: Addresses symptom in specific environment, not root cause or pattern
+```
+
+**Example 3: Personal workflow**
+```
+Skill: "My preferred way to organize code"
+Content: "I like to put all API calls in src/api/ folder"
+Why bad: Personal preference without objective benefit or widespread adoption
+```
+
+**Example 4: Narrow tool usage**
+```
+Skill: "How I used library X for project Y"
+Content: Specific implementation details for one project
+Why bad: Too narrow - describes one implementation vs teaching general patterns
+```
+
+### ✅ Appropriately General (Good contributions)
+
+**Example 1: General pattern**
+```
+Skill: "Database connection pooling patterns"
+Content: When to use pooling, configuration strategies, common pitfalls
+Why good: Applies to any database connection, teaches principles
+```
+
+**Example 2: Universal problem**
+```
+Skill: "Handling API rate limits with exponential backoff"
+Content: Pattern, implementation strategies, when to use
+Why good: Common problem with well-established solution, broadly applicable
+```
+
+**Example 3: Framework-agnostic principle**
+```
+Skill: "Error handling in async operations"
+Content: Strategies for retry, timeout, graceful degradation
+Why good: Teaches concepts that apply across languages/frameworks
+```
+
+**Example 4: Tool pattern**
+```
+Skill: "Testing strategies for web applications"
+Content: When to use unit vs integration vs e2e tests, how to structure tests
+Why good: Principles apply regardless of specific testing framework
+```
+
+### The Test: "Would this help an agent working on a different project?"
+
+**Ask yourself:**
+- Would an agent working on a completely different project find this useful?
+- Does this teach a pattern/principle or just document my specific setup?
+- Am I solving a universal problem or my unique situation?
+- Is this "how to think about X" or "what I did for Y"?
+
+**If the answer is "this only helps agents working on my exact project" → Too specific**
 
 ## Validation Methods
 


### PR DESCRIPTION
## What

Updates skill-learning-patterns to strongly emphasize that skills must contain general-purpose knowledge, not project-specific solutions.

## Why

An agent submitted contributions that were too specific to their use case rather than providing generalizable knowledge. This creates noise in the repository and doesn't help other agents.

Examples of overly-specific contributions:
- Company-specific API endpoints and credentials
- Environment-specific workarounds
- Personal code organization preferences
- Single-project implementation details

These don't belong in a communal skill repository.

## Changes

**SKILL.md:**
- Added prominent warning after "Core Philosophy" about general-purpose requirement
- Made generalizability the first validation criterion (marked "Most critical")
- Expanded "Do NOT contribute" with 5 specific anti-patterns

**validation-criteria.md:**
- Marked generalizability section as "CRITICAL"
- Added concrete examples: project configs vs general patterns
- New "Specific vs General: Examples" section with 8 examples (4 bad, 4 good)
- Added "The Test" question: "Would this help an agent on a different project?"

**recognizing-learnings.md:**
- Expanded "When NOT to Contribute" into 4 detailed categories
- Each category includes explanation + concrete examples
- Shows how to transform specific learnings into general patterns
- Reinforces the test throughout

## Impact

Helps agents distinguish between:
- ✅ "API rate limiting with exponential backoff" (general pattern)
- ❌ "Our API endpoint is https://api.acme.com/v2/users" (project-specific)

Sets clear expectations that this repository is for patterns, principles, and broadly applicable practices—not project configurations or narrow solutions.

## Testing

Reviewed against real examples of overly-specific contributions. Clear guidance now prevents these issues.

Written by Cameron ◯ Letta Code
