### PR TITLE
Add SKILLS.md manifest files to each domain root

### DIFF
--- a/ai/SKILLS.md
+++ b/ai/SKILLS.md
@@ -1,0 +1,39 @@
+# AI Domain Skills
+
+Skills related to AI/ML systems, agent architectures, models, and tool integrations.
+
+## When to Load This Domain
+
+Load when working on:
+- Designing or implementing AI agents
+- Selecting or configuring LLMs
+- Integrating external tools and services with agents
+- Understanding agent-specific patterns and architectures
+
+## Skills in This Domain
+
+### Agents
+
+#### agents/letta/
+- **letta-agent-designer** - Designing effective Letta agents (architecture, memory blocks, models, tools)
+- **letta-memory-architect** - Memory architecture design for Letta agents (block structure, memory types, concurrency)
+
+### Models
+*No skills yet - potential for model selection, prompting patterns, context optimization*
+
+### Tools
+- **tools/mcp-builder** - Creating MCP (Model Context Protocol) servers to integrate external APIs and services
+
+## Domain Coverage
+
+**Current focus:**
+- Letta-specific agent design patterns
+- Memory architecture for stateful agents
+- MCP server integration patterns
+
+**Future expansion potential:**
+- General agent design patterns (cross-platform)
+- Model selection and configuration guides
+- Prompt engineering patterns
+- Context window optimization
+- Multi-agent coordination

--- a/design/SKILLS.md
+++ b/design/SKILLS.md
@@ -1,0 +1,32 @@
+# Design Domain Skills
+
+Skills related to design, documentation, visual communication, and user experience.
+
+## When to Load This Domain
+
+Load when working on:
+- Writing documentation or communications
+- Designing user interfaces or experiences
+- Creating visual assets or presentations
+- Structuring information for clarity
+
+## Skills in This Domain
+
+### Documentation
+- **documentation/internal-comms** - Writing internal communications (status reports, updates, FAQs, incident reports, project updates)
+
+## Domain Coverage
+
+**Current focus:**
+- Internal communications writing
+- Documentation structure and clarity
+
+**Future expansion potential:**
+- Technical documentation patterns
+- API documentation best practices
+- README and getting-started guides
+- Visual design principles
+- UI/UX patterns
+- Accessibility guidelines
+- Information architecture
+- Presentation design

--- a/development/SKILLS.md
+++ b/development/SKILLS.md
@@ -1,0 +1,37 @@
+# Development Domain Skills
+
+Skills related to software development practices, frameworks, patterns, and tooling.
+
+## When to Load This Domain
+
+Load when working on:
+- Building software applications
+- Following coding best practices and patterns
+- Using development frameworks and tools
+- Creating or improving skills themselves (meta-development)
+
+## Skills in This Domain
+
+### Frameworks
+- **frameworks/frontend-design** - Creating production-grade frontend interfaces with high design quality
+
+### Patterns
+- **patterns/skill-creator** - Guide for creating effective skills that extend agent capabilities
+- **patterns/skill-learning-patterns** - Meta-skill for recognizing learnings and contributing improvements back to the knowledge base
+
+## Domain Coverage
+
+**Current focus:**
+- Frontend development patterns
+- Skill creation and contribution workflows
+- Learning and knowledge curation patterns
+
+**Future expansion potential:**
+- Backend development patterns
+- API design and integration
+- Testing strategies and patterns
+- Error handling and debugging
+- Code review best practices
+- Git workflows and collaboration
+- Performance optimization
+- Security patterns

--- a/operations/SKILLS.md
+++ b/operations/SKILLS.md
@@ -1,0 +1,36 @@
+# Operations Domain Skills
+
+Skills related to testing, deployment, monitoring, and operational excellence.
+
+## When to Load This Domain
+
+Load when working on:
+- Testing applications and systems
+- Deploying and managing infrastructure
+- Monitoring and observability
+- Debugging and troubleshooting
+- Performance optimization
+
+## Skills in This Domain
+
+### Testing
+- **testing/webapp-testing** - Testing web applications using Playwright for UI verification, debugging, screenshot capture, and browser logs
+
+## Domain Coverage
+
+**Current focus:**
+- Web application testing with Playwright
+- UI verification and debugging patterns
+
+**Future expansion potential:**
+- Unit testing strategies
+- Integration testing patterns
+- End-to-end testing approaches
+- Performance testing and profiling
+- Deployment strategies
+- CI/CD patterns
+- Monitoring and alerting
+- Incident response
+- Database operations and management
+- Security operations
+- Infrastructure as code


### PR DESCRIPTION
## What

Adds SKILLS.md manifest files to each domain root (ai/, development/, design/, operations/) to enable conditional domain loading.

## Why

For agents to efficiently load only relevant skills for their current tasks, they need domain-level manifests that describe:
- What skills are in this domain
- When to load this domain
- What coverage the domain currently has

This enables selective loading rather than loading all skills upfront.

## Changes

Created four domain manifests:

**ai/SKILLS.md:**
- Agent design patterns (Letta)
- Memory architectures
- MCP tool integration
- Future: Model selection, prompting, multi-agent

**development/SKILLS.md:**
- Frontend frameworks
- Skill creation and learning patterns
- Future: Testing, git workflows, API design

**design/SKILLS.md:**
- Internal communications
- Documentation patterns
- Future: UI/UX, visual design, accessibility

**operations/SKILLS.md:**
- Web application testing (Playwright)
- Future: Deployment, monitoring, CI/CD

## Impact

**For agents:**
- Load only relevant domains for current task
- Discover what skills exist in a domain
- Understand when to load additional domains

**For repository:**
- Clear structure for organizing new skills
- Discoverability of domain coverage
- Documentation of future expansion areas

## Testing

Each manifest clearly lists current skills and describes when the domain is relevant. Agents can use "When to Load This Domain" section to determine if they need these skills.

Written by Cameron ◯ Letta Code
