### PR TITLE
fix: set Keeper as default agent for @letta-code mentions

### DIFF
--- a/.github/workflows/letta.yml
+++ b/.github/workflows/letta.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           letta_api_key: ${{ secrets.LETTA_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          letta_args: "--agent agent-627d9a86-630f-462c-98c1-4929c6d3d941"


### PR DESCRIPTION
Sets Keeper (agent-627d9a86-630f-462c-98c1-4929c6d3d941) as the default agent for all `@letta-code` mentions in this repository.

## Why

Keeper is the designated curator for the skills repository with:
- Comprehensive review standards and validation checklists
- Knowledge of repository structure and contribution guidelines
- Authority to approve, request changes, or reject skill submissions
- Memory prepared with common review patterns and responses

## Change

Adds `letta_args: "--agent agent-627d9a86-630f-462c-98c1-4929c6d3d941"` to the workflow configuration.

## Override

Contributors can still use a different agent if needed:
```
@letta-code [--agent other-id] message
```