### PR TITLE
feat: add extracting-pdf-text skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Local environment directories
 .skills/
 .letta/
+.env

--- a/tools/extracting-pdf-text/SKILL.md
+++ b/tools/extracting-pdf-text/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: extracting-pdf-text
+description: Extract text from PDFs for LLM consumption. Use when processing PDFs for RAG, document analysis, or text extraction. Supports API services (Mistral OCR) and local tools (PyMuPDF, pdfplumber). Handles text-based PDFs, tables, and scanned documents with OCR.
+---
+
+# Extracting PDF Text for LLMs
+
+This skill provides tools and guidance for extracting text from PDFs in formats suitable for language model consumption.
+
+## Quick Decision Guide
+
+| PDF Type | Best Approach | Script |
+|----------|--------------|--------|
+| Simple text PDF | PyMuPDF | `scripts/extract_pymupdf.py` |
+| PDF with tables | pdfplumber | `scripts/extract_pdfplumber.py` |
+| Scanned/image PDF (local) | pytesseract | `scripts/extract_with_ocr.py` |
+| Complex layout, highest accuracy | Mistral OCR API | `scripts/extract_mistral_ocr.py` |
+| End-to-end RAG pipeline | marker-pdf | `pip install marker-pdf` |
+
+## Recommended Workflow
+
+1. **Try PyMuPDF first** - fastest, handles most text-based PDFs well
+2. **If tables are mangled** - switch to pdfplumber
+3. **If scanned/image-based** - use Mistral OCR API (best accuracy) or local OCR (free but slower)
+
+## Local Extraction (No API Required)
+
+### PyMuPDF - Fast General Extraction
+
+Best for: Text-heavy PDFs, speed-critical workflows, basic structure preservation.
+
+```bash
+uv run scripts/extract_pymupdf.py input.pdf output.md
+```
+
+The script outputs markdown with preserved headings and paragraphs. For LLM-optimized output, it uses `pymupdf4llm` which formats text for RAG systems.
+
+### pdfplumber - Table Extraction
+
+Best for: PDFs with tables, financial documents, structured data.
+
+```bash
+uv run scripts/extract_pdfplumber.py input.pdf output.md
+```
+
+Tables are converted to markdown format. Note: pdfplumber works best on machine-generated PDFs, not scanned documents.
+
+### Local OCR - Scanned Documents
+
+Best for: Scanned PDFs when API access is unavailable.
+
+```bash
+uv run scripts/extract_with_ocr.py input.pdf output.txt
+```
+
+Requires: `pytesseract`, `pdf2image`, and Tesseract installed (`brew install tesseract` on macOS).
+
+## API-Based Extraction
+
+### Mistral OCR API
+
+Best for: Complex layouts, scanned documents, highest accuracy, multilingual content, math formulas.
+
+**Pricing**: ~1000 pages per dollar (very cost-effective)
+
+```bash
+export MISTRAL_API_KEY="your-key"
+uv run scripts/extract_mistral_ocr.py input.pdf output.md
+```
+
+Features:
+- Outputs clean markdown
+- Preserves document structure (headings, lists, tables)
+- Handles images, math equations, multilingual text
+- 95%+ accuracy on complex documents
+
+For detailed API options and other services, see [references/api-services.md](references/api-services.md).
+
+## Output Format Recommendations
+
+For LLM consumption, markdown is preferred:
+- Preserves semantic structure (headings become context boundaries)
+- Tables remain readable
+- Compatible with most RAG chunking strategies
+
+For detailed comparisons of local tools, see [references/local-tools.md](references/local-tools.md).

--- a/tools/extracting-pdf-text/references/api-services.md
+++ b/tools/extracting-pdf-text/references/api-services.md
@@ -1,0 +1,174 @@
+# API Services for PDF Extraction
+
+## Mistral OCR API (Recommended)
+
+**Best for**: Complex layouts, scanned documents, multilingual content, math formulas.
+
+**Pricing**: ~$1 per 1000 pages (very cost-effective)
+
+**Accuracy**: 95%+ overall, 98%+ on scanned documents
+
+### Features
+- Outputs clean markdown preserving document structure
+- Table recognition (96% accuracy)
+- Math equation support (94% accuracy)
+- Multilingual support (89% accuracy)
+- Processes up to 2000 pages/minute
+
+### API Usage
+
+```python
+from mistralai import Mistral
+import base64
+
+client = Mistral(api_key="your-key")
+
+# From URL
+response = client.ocr.process(
+    model="mistral-ocr-latest",
+    document={
+        "type": "document_url",
+        "document_url": "https://example.com/doc.pdf",
+    }
+)
+
+# From local file (base64)
+with open("doc.pdf", "rb") as f:
+    content = base64.standard_b64encode(f.read()).decode()
+
+response = client.ocr.process(
+    model="mistral-ocr-latest",
+    document={
+        "type": "base64",
+        "base64": content,
+    }
+)
+
+# Access results
+for page in response.pages:
+    print(page.markdown)
+```
+
+### Endpoint
+- SDK: `client.ocr.process`
+- REST: `POST https://api.mistral.ai/v1/ocr`
+
+---
+
+## OpenAI Vision (GPT-4V)
+
+**Best for**: When you already have OpenAI API access and need to extract from image-heavy PDFs.
+
+**Approach**: Convert PDF pages to images, send to GPT-4V for extraction.
+
+**Pricing**: ~$0.01-0.03 per page (depends on image size and detail level)
+
+### Usage Pattern
+
+```python
+from openai import OpenAI
+from pdf2image import convert_from_path
+import base64
+from io import BytesIO
+
+client = OpenAI()
+
+def pdf_page_to_base64(image):
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode()
+
+# Convert PDF to images
+images = convert_from_path("doc.pdf", dpi=150)
+
+for i, img in enumerate(images):
+    b64 = pdf_page_to_base64(img)
+    
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Extract all text from this document page. Preserve structure and formatting as markdown."},
+                {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}}
+            ]
+        }]
+    )
+    print(response.choices[0].message.content)
+```
+
+### Limitations
+- Requires converting PDF to images first
+- Higher cost per page than Mistral OCR
+- May struggle with dense text
+
+---
+
+## Google Cloud Document AI
+
+**Best for**: Enterprise workflows, high-volume processing, Google Cloud integration.
+
+**Pricing**: $1.50 per 1000 pages (Form Parser), varies by processor type
+
+### Processors
+- Document OCR: General text extraction
+- Form Parser: Structured form data
+- Invoice Parser: Specialized invoice extraction
+- Custom Document Extractor: Train on your document types
+
+Not covered in detail here - see [Google Cloud documentation](https://cloud.google.com/document-ai/docs).
+
+---
+
+## AWS Textract
+
+**Best for**: AWS ecosystem integration, form extraction, table detection.
+
+**Pricing**: $1.50 per 1000 pages (text), $15 per 1000 pages (tables/forms)
+
+### Features
+- DetectDocumentText: Basic OCR
+- AnalyzeDocument: Tables, forms, key-value pairs
+- AnalyzeExpense: Receipt/invoice parsing
+
+Not covered in detail here - see [AWS Textract documentation](https://docs.aws.amazon.com/textract/).
+
+---
+
+---
+
+## Azure Document Intelligence
+
+**Best for**: Enterprise workflows, highest accuracy on structured documents.
+
+Formerly "Azure Form Recognizer". Ranked #1 in several 2025 OCR benchmarks.
+
+**Pricing**: ~$1.50 per 1000 pages (Read model), higher for specialized models
+
+### Features
+- Prebuilt models for invoices, receipts, IDs, tax forms
+- Custom model training
+- Excellent table and form extraction
+- Strong multilingual support
+
+### Models
+- **Read**: General OCR
+- **Layout**: Structure + tables
+- **Invoice/Receipt/ID**: Specialized extractors
+- **Custom**: Train on your documents
+
+Not covered in detail - see [Azure documentation](https://learn.microsoft.com/azure/ai-services/document-intelligence/).
+
+---
+
+## Comparison Summary
+
+| Service | Cost/1000 pages | Best For | Output Format |
+|---------|----------------|----------|---------------|
+| Mistral OCR | ~$1 | General, scanned, complex | Markdown |
+| Azure Doc Intel | ~$1.50 | Enterprise, forms, highest accuracy | JSON |
+| OpenAI Vision | ~$10-30 | Image-heavy, existing OpenAI users | Text |
+| Google Doc AI | $1.50+ | Enterprise, Google Cloud | JSON |
+| AWS Textract | $1.50-15 | AWS users, forms | JSON |
+
+**Recommendation**: Start with Mistral OCR for best price/performance ratio. Use Azure Document Intelligence if you need highest accuracy on forms/invoices.

--- a/tools/extracting-pdf-text/references/local-tools.md
+++ b/tools/extracting-pdf-text/references/local-tools.md
@@ -1,0 +1,296 @@
+# Local PDF Extraction Tools
+
+## PyMuPDF (fitz) + pymupdf4llm
+
+**Best for**: Fast extraction, LLM-optimized output, complex layouts.
+
+**Speed**: Fastest option (~0.01s per page)
+
+### Installation
+```bash
+pip install pymupdf4llm
+# or with uv
+uv pip install pymupdf4llm
+```
+
+### Usage
+
+```python
+import pymupdf4llm
+
+# Basic extraction to markdown
+md_text = pymupdf4llm.to_markdown("document.pdf")
+
+# With options
+md_text = pymupdf4llm.to_markdown(
+    "document.pdf",
+    pages=[0, 1, 2],  # specific pages (0-indexed)
+    page_chunks=True,  # return list of page chunks for RAG
+)
+
+# For RAG systems - get chunks with metadata
+chunks = pymupdf4llm.to_markdown("document.pdf", page_chunks=True)
+for chunk in chunks:
+    print(f"Page {chunk['metadata']['page']}: {chunk['text'][:100]}...")
+```
+
+### Strengths
+- Fastest Python PDF library
+- Good structure preservation (headings, lists)
+- LLM-optimized markdown output
+- Handles images and complex layouts
+- Active development
+
+### Limitations
+- Struggles with some scanned documents
+- Table extraction less reliable than pdfplumber
+
+---
+
+## pdfplumber
+
+**Best for**: Table extraction, machine-generated PDFs, detailed layout control.
+
+**Speed**: Moderate (~0.1s per page)
+
+### Installation
+```bash
+pip install pdfplumber
+```
+
+### Usage
+
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    for page in pdf.pages:
+        # Extract text
+        text = page.extract_text()
+        
+        # Extract tables
+        tables = page.extract_tables()
+        for table in tables:
+            for row in table:
+                print(row)
+        
+        # Visual debugging
+        im = page.to_image()
+        im.draw_rects(page.chars)
+        im.save("debug.png")
+```
+
+### Table Extraction Options
+
+```python
+# Custom table settings for complex tables
+table_settings = {
+    "vertical_strategy": "text",
+    "horizontal_strategy": "text",
+    "snap_tolerance": 3,
+    "join_tolerance": 3,
+}
+
+tables = page.extract_tables(table_settings)
+```
+
+### Strengths
+- Excellent table detection and extraction
+- Fine-grained control over extraction
+- Visual debugging tools
+- Good for structured documents
+
+### Limitations
+- Slower than PyMuPDF
+- Does not work well on scanned PDFs
+- Built on pdfminer.six (can be memory-heavy)
+
+---
+
+## unstructured
+
+**Best for**: RAG systems, semantic chunking, multi-format support.
+
+**Speed**: Slower (includes ML models)
+
+### Installation
+```bash
+pip install unstructured[pdf]
+# For full features including OCR:
+pip install unstructured[all-docs]
+```
+
+### Usage
+
+```python
+from unstructured.partition.pdf import partition_pdf
+
+# Basic extraction
+elements = partition_pdf("document.pdf")
+
+for element in elements:
+    print(f"{element.category}: {element.text[:100]}")
+
+# With OCR for scanned documents
+elements = partition_pdf(
+    "scanned.pdf",
+    strategy="ocr_only",  # or "hi_res" for best quality
+)
+
+# Chunking for RAG
+from unstructured.chunking.title import chunk_by_title
+chunks = chunk_by_title(elements)
+```
+
+### Strengths
+- Semantic element detection (titles, paragraphs, tables)
+- Built-in chunking strategies for RAG
+- Multi-format support (PDF, DOCX, HTML, etc.)
+- OCR support included
+
+### Limitations
+- Heavier dependencies
+- Slower processing
+- More complex setup
+
+---
+
+## pytesseract + pdf2image
+
+**Best for**: Scanned PDFs when API access unavailable.
+
+**Speed**: Slow (~1-3s per page)
+
+### Prerequisites
+```bash
+# macOS
+brew install tesseract poppler
+
+# Ubuntu
+apt-get install tesseract-ocr poppler-utils
+```
+
+### Installation
+```bash
+pip install pytesseract pdf2image Pillow
+```
+
+### Usage
+
+```python
+import pytesseract
+from pdf2image import convert_from_path
+
+# Convert PDF to images
+images = convert_from_path("scanned.pdf", dpi=300)
+
+# OCR each page
+for i, image in enumerate(images):
+    text = pytesseract.image_to_string(image, lang="eng")
+    print(f"Page {i+1}:\n{text}")
+
+# Multiple languages
+text = pytesseract.image_to_string(image, lang="eng+fra+deu")
+```
+
+### Strengths
+- Free and open source
+- Works offline
+- Supports 100+ languages
+
+### Limitations
+- Requires system dependencies (Tesseract, Poppler)
+- Lower accuracy than cloud OCR services
+- No structure preservation
+
+---
+
+## Comparison Summary
+
+| Tool | Speed | Tables | Scanned PDFs | RAG-Ready |
+|------|-------|--------|--------------|-----------|
+| pymupdf4llm | Fastest | Good | Limited | Yes |
+| pdfplumber | Moderate | Excellent | No | Manual |
+| unstructured | Slow | Good | Yes (with OCR) | Yes |
+| pytesseract | Slow | No | Yes | No |
+
+### Decision Guide
+
+1. **Need speed?** → pymupdf4llm
+2. **Need tables?** → pdfplumber
+3. **Building RAG?** → unstructured or pymupdf4llm with page_chunks
+4. **Scanned docs, no API?** → pytesseract (or unstructured with OCR)
+5. **Scanned docs, have budget?** → Mistral OCR API (see api-services.md)
+
+---
+
+## Additional Tools Worth Knowing
+
+### marker-pdf (Datalab)
+
+**Best for**: End-to-end PDF to Markdown conversion, RAG pipelines.
+
+Built on Surya OCR engine. Very popular for document processing pipelines.
+
+```bash
+pip install marker-pdf
+marker_single input.pdf --output_dir ./output --output_format markdown
+```
+
+Features:
+- Outputs clean Markdown, JSON, or HTML
+- Handles complex layouts
+- Optional LLM post-processing for cleanup
+- GPU-accelerated
+
+### surya
+
+**Best for**: Core OCR engine, multilingual text detection.
+
+The OCR engine that powers marker-pdf. Good for custom pipelines.
+
+```bash
+pip install surya-ocr
+```
+
+### docling (IBM)
+
+**Best for**: Enterprise document parsing, structured extraction.
+
+```bash
+pip install docling
+```
+
+### MinerU
+
+**Best for**: Academic papers, complex multi-column layouts.
+
+Open source PDF parser with excellent layout detection.
+
+```bash
+pip install magic-pdf
+```
+
+### PaddleOCR (Baidu)
+
+**Best for**: Chinese/multilingual documents, structured forms.
+
+```bash
+pip install paddlepaddle paddleocr
+```
+
+Excellent for Asian languages. Requires some tuning for optimal results.
+
+---
+
+## Full Comparison
+
+| Tool | Speed | Scanned PDFs | Tables | RAG-Ready | Best For |
+|------|-------|--------------|--------|-----------|----------|
+| pymupdf4llm | Fastest | Limited | Good | Yes | Speed |
+| pdfplumber | Moderate | No | Excellent | Manual | Tables |
+| marker-pdf | Moderate | Yes | Good | Yes | End-to-end |
+| unstructured | Slow | Yes | Good | Yes | RAG |
+| pytesseract | Slow | Yes | No | No | Free OCR |
+| MinerU | Moderate | Yes | Good | Yes | Academic |
+| PaddleOCR | Fast | Yes | Good | Manual | Multilingual |

--- a/tools/extracting-pdf-text/scripts/extract_mistral_ocr.py
+++ b/tools/extracting-pdf-text/scripts/extract_mistral_ocr.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Extract text from PDF using Mistral OCR API.
+Best for complex layouts, scanned documents, and highest accuracy.
+
+Usage:
+    export MISTRAL_API_KEY="your-key"
+    uv run extract_mistral_ocr.py input.pdf output.md
+    uv run extract_mistral_ocr.py input.pdf  # prints to stdout
+    uv run extract_mistral_ocr.py https://example.com/doc.pdf output.md  # URL input
+
+Requirements (auto-installed by uv):
+    mistralai
+"""
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["mistralai>=1.0.0"]
+# ///
+
+import os
+import sys
+import base64
+from pathlib import Path
+
+
+def extract_with_mistral_ocr(source: str) -> str:
+    """
+    Extract PDF content using Mistral OCR API.
+    
+    Args:
+        source: Local file path or URL to PDF
+        
+    Returns:
+        Extracted text in markdown format
+    """
+    from mistralai import Mistral
+    
+    api_key = os.environ.get("MISTRAL_API_KEY")
+    if not api_key:
+        raise ValueError("MISTRAL_API_KEY environment variable not set")
+    
+    client = Mistral(api_key=api_key)
+    
+    # Determine if source is URL or local file
+    if source.startswith("http://") or source.startswith("https://"):
+        # URL-based document
+        ocr_response = client.ocr.process(
+            model="mistral-ocr-latest",
+            document={
+                "type": "document_url",
+                "document_url": source,
+            }
+        )
+    else:
+        # Local file - upload as base64
+        file_path = Path(source)
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {source}")
+        
+        with open(file_path, "rb") as f:
+            file_content = base64.standard_b64encode(f.read()).decode("utf-8")
+        
+        ocr_response = client.ocr.process(
+            model="mistral-ocr-latest",
+            document={
+                "type": "base64",
+                "base64": file_content,
+            }
+        )
+    
+    # Combine all pages into markdown
+    output_parts = []
+    for page in ocr_response.pages:
+        output_parts.append(page.markdown)
+    
+    return "\n\n---\n\n".join(output_parts)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: uv run extract_mistral_ocr.py <input.pdf|url> [output.md]", file=sys.stderr)
+        print("       MISTRAL_API_KEY environment variable must be set", file=sys.stderr)
+        sys.exit(1)
+    
+    source = sys.argv[1]
+    output_path = sys.argv[2] if len(sys.argv) > 2 else None
+    
+    try:
+        result = extract_with_mistral_ocr(source)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    if output_path:
+        Path(output_path).write_text(result, encoding="utf-8")
+        print(f"Extracted {len(result)} characters to {output_path}")
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/extracting-pdf-text/scripts/extract_pdfplumber.py
+++ b/tools/extracting-pdf-text/scripts/extract_pdfplumber.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Extract text and tables from PDF using pdfplumber.
+Best for machine-generated PDFs with tables.
+
+Usage:
+    uv run extract_pdfplumber.py input.pdf output.md
+    uv run extract_pdfplumber.py input.pdf  # prints to stdout
+
+Requirements (auto-installed by uv):
+    pdfplumber
+"""
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pdfplumber>=0.11.0"]
+# ///
+
+import sys
+from pathlib import Path
+
+
+def table_to_markdown(table: list[list]) -> str:
+    """Convert a table (list of rows) to markdown format."""
+    if not table or not table[0]:
+        return ""
+    
+    # Clean None values
+    table = [[cell or "" for cell in row] for row in table]
+    
+    lines = []
+    # Header row
+    lines.append("| " + " | ".join(str(cell) for cell in table[0]) + " |")
+    # Separator
+    lines.append("| " + " | ".join("---" for _ in table[0]) + " |")
+    # Data rows
+    for row in table[1:]:
+        lines.append("| " + " | ".join(str(cell) for cell in row) + " |")
+    
+    return "\n".join(lines)
+
+
+def extract_pdf_with_tables(pdf_path: str) -> str:
+    """Extract PDF content with tables formatted as markdown."""
+    import pdfplumber
+    
+    output_parts = []
+    
+    with pdfplumber.open(pdf_path) as pdf:
+        for i, page in enumerate(pdf.pages, 1):
+            output_parts.append(f"\n## Page {i}\n")
+            
+            # Extract tables first to identify their bounding boxes
+            tables = page.extract_tables()
+            table_bboxes = []
+            
+            if tables:
+                # Find table locations
+                for table_settings in page.find_tables():
+                    table_bboxes.append(table_settings.bbox)
+            
+            # Extract text (excluding table areas if possible)
+            text = page.extract_text() or ""
+            if text.strip():
+                output_parts.append(text.strip())
+            
+            # Add tables as markdown
+            for j, table in enumerate(tables, 1):
+                if table:
+                    output_parts.append(f"\n### Table {j}\n")
+                    output_parts.append(table_to_markdown(table))
+    
+    return "\n\n".join(output_parts)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: uv run extract_pdfplumber.py <input.pdf> [output.md]", file=sys.stderr)
+        sys.exit(1)
+    
+    input_path = sys.argv[1]
+    output_path = sys.argv[2] if len(sys.argv) > 2 else None
+    
+    if not Path(input_path).exists():
+        print(f"Error: File not found: {input_path}", file=sys.stderr)
+        sys.exit(1)
+    
+    result = extract_pdf_with_tables(input_path)
+    
+    if output_path:
+        Path(output_path).write_text(result, encoding="utf-8")
+        print(f"Extracted {len(result)} characters to {output_path}")
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/extracting-pdf-text/scripts/extract_pymupdf.py
+++ b/tools/extracting-pdf-text/scripts/extract_pymupdf.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Extract text from PDF using PyMuPDF (fitz).
+Outputs LLM-optimized markdown using pymupdf4llm.
+
+Usage:
+    uv run extract_pymupdf.py input.pdf output.md
+    uv run extract_pymupdf.py input.pdf  # prints to stdout
+
+Requirements (auto-installed by uv):
+    pymupdf4llm
+"""
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pymupdf4llm>=0.0.17"]
+# ///
+
+import sys
+from pathlib import Path
+
+
+def extract_pdf_to_markdown(pdf_path: str) -> str:
+    """Extract PDF content as LLM-optimized markdown."""
+    import pymupdf4llm
+    
+    md_text = pymupdf4llm.to_markdown(pdf_path)
+    return md_text
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: uv run extract_pymupdf.py <input.pdf> [output.md]", file=sys.stderr)
+        sys.exit(1)
+    
+    input_path = sys.argv[1]
+    output_path = sys.argv[2] if len(sys.argv) > 2 else None
+    
+    if not Path(input_path).exists():
+        print(f"Error: File not found: {input_path}", file=sys.stderr)
+        sys.exit(1)
+    
+    result = extract_pdf_to_markdown(input_path)
+    
+    if output_path:
+        Path(output_path).write_text(result, encoding="utf-8")
+        print(f"Extracted {len(result)} characters to {output_path}")
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/extracting-pdf-text/scripts/extract_with_ocr.py
+++ b/tools/extracting-pdf-text/scripts/extract_with_ocr.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Extract text from scanned PDFs using local OCR (Tesseract).
+Use this when API access is unavailable for scanned/image-based PDFs.
+
+Usage:
+    uv run extract_with_ocr.py input.pdf output.txt
+    uv run extract_with_ocr.py input.pdf  # prints to stdout
+
+Prerequisites:
+    - Tesseract OCR installed: brew install tesseract (macOS)
+    - Poppler for pdf2image: brew install poppler (macOS)
+
+Requirements (auto-installed by uv):
+    pytesseract, pdf2image, Pillow
+"""
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pytesseract>=0.3.10", "pdf2image>=1.16.0", "Pillow>=10.0.0"]
+# ///
+
+import sys
+import shutil
+from pathlib import Path
+
+
+def check_dependencies():
+    """Check that required system dependencies are installed."""
+    if not shutil.which("tesseract"):
+        print("Error: Tesseract not found. Install with: brew install tesseract", file=sys.stderr)
+        sys.exit(1)
+    
+    # Check for poppler (pdftoppm)
+    if not shutil.which("pdftoppm"):
+        print("Error: Poppler not found. Install with: brew install poppler", file=sys.stderr)
+        sys.exit(1)
+
+
+def extract_pdf_with_ocr(pdf_path: str, lang: str = "eng") -> str:
+    """
+    Extract text from scanned PDF using OCR.
+    
+    Args:
+        pdf_path: Path to PDF file
+        lang: Tesseract language code (default: eng)
+        
+    Returns:
+        Extracted text
+    """
+    import pytesseract
+    from pdf2image import convert_from_path
+    
+    # Convert PDF pages to images
+    images = convert_from_path(pdf_path, dpi=300)
+    
+    output_parts = []
+    for i, image in enumerate(images, 1):
+        # Run OCR on each page
+        text = pytesseract.image_to_string(image, lang=lang)
+        if text.strip():
+            output_parts.append(f"--- Page {i} ---\n{text.strip()}")
+    
+    return "\n\n".join(output_parts)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: uv run extract_with_ocr.py <input.pdf> [output.txt] [--lang=eng]", file=sys.stderr)
+        sys.exit(1)
+    
+    check_dependencies()
+    
+    input_path = sys.argv[1]
+    output_path = None
+    lang = "eng"
+    
+    for arg in sys.argv[2:]:
+        if arg.startswith("--lang="):
+            lang = arg.split("=")[1]
+        else:
+            output_path = arg
+    
+    if not Path(input_path).exists():
+        print(f"Error: File not found: {input_path}", file=sys.stderr)
+        sys.exit(1)
+    
+    print(f"Processing PDF with OCR (language: {lang})...", file=sys.stderr)
+    result = extract_pdf_with_ocr(input_path, lang=lang)
+    
+    if output_path:
+        Path(output_path).write_text(result, encoding="utf-8")
+        print(f"Extracted {len(result)} characters to {output_path}")
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New skill for extracting text from PDFs for LLM consumption
- 4 Python scripts with uv inline dependencies (PEP 723):
  - `extract_pymupdf.py` - fast local extraction
  - `extract_pdfplumber.py` - table-focused extraction
  - `extract_mistral_ocr.py` - Mistral API for complex/scanned docs
  - `extract_with_ocr.py` - local OCR with pytesseract
- Decision guide for choosing the right approach
- Reference docs covering API services (Mistral, Azure, Google, AWS) and local tools (marker-pdf, surya, docling, MinerU, PaddleOCR)

## Test plan
- [x] Tested extract_pymupdf.py with simple PDF
- [x] Tested extract_pdfplumber.py with simple PDF
- [x] Tested extract_mistral_ocr.py with 29-page arXiv paper (111K chars extracted)
- [ ] extract_with_ocr.py requires Tesseract installed (not tested)

## Structure
```
tools/extracting-pdf-text/
├── SKILL.md
├── scripts/
│   ├── extract_pymupdf.py
│   ├── extract_pdfplumber.py
│   ├── extract_mistral_ocr.py
│   └── extract_with_ocr.py
└── references/
    ├── api-services.md
    └── local-tools.md
```