### PR TITLE
feat: add Slack integration tool

### DIFF
--- a/tools/slack/SKILL.md
+++ b/tools/slack/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: slack
+description: Search messages, read threads, and send messages in Slack. Use when looking up discussions, finding context about a topic, or sending notifications to channels.
+---
+
+# Slack
+
+Search and interact with Slack workspaces from the command line.
+
+## Important: Token Security
+
+**NEVER include `$SLACK_TOKEN` directly in curl commands.** The token will be logged and exposed.
+
+Always use the wrapper scripts which read the token from the environment internally:
+- `slack send` - not `curl ... -H "Authorization: Bearer $SLACK_TOKEN"`
+- `slack-api POST ...` - for advanced API calls
+
+## Quick Setup (New Users)
+
+```bash
+# Add scripts to PATH
+export PATH="$PATH:$HOME/.letta/skills/slack/scripts"
+
+# Create Slack app with one click (opens browser)
+slack-setup
+```
+
+This opens Slack's app creation page with all permissions pre-configured. Then:
+1. Click **Create** to create the app
+2. Go to **OAuth & Permissions** → **Install to Workspace**
+3. Copy the **User OAuth Token** (`xoxp-...`) - NOT the bot token
+4. Set it in your shell:
+   ```bash
+   export SLACK_TOKEN="xoxp-..."
+   ```
+
+**Why user token?** Bot tokens (`xoxb-`) cannot search messages (Slack limitation). User tokens can do everything bots can, plus search.
+
+## Quick Setup (Existing Token)
+
+```bash
+export SLACK_TOKEN="xoxp-..."   # User token (recommended) or xoxb- bot token
+export PATH="$PATH:$HOME/.letta/skills/slack/scripts"
+```
+
+## Commands
+
+### Search messages
+
+```bash
+slack search "deployment failed"
+slack search "from:@caren database"
+slack search "in:#engineering api"
+slack search "in:#engineering after:2024-01-01 bug"
+```
+
+Search supports Slack's modifiers: `from:`, `in:`, `to:`, `has:link`, `has:reaction`, `before:`, `after:`, `on:`.
+
+### Send messages
+
+```bash
+slack send "#general" "Hello team!"
+slack send "#alerts" ":rocket: Deployment complete"
+slack send "@caren" "Quick question..."
+```
+
+### Join a channel
+
+The bot must be a member of a channel to read its history. Join public channels with:
+
+```bash
+slack join "#engineering"
+```
+
+For private channels, someone must invite the bot manually via Slack.
+
+### List channels
+
+```bash
+slack channels
+```
+
+### Read channel history
+
+```bash
+slack history "#engineering"
+slack history "#engineering" 50    # Last 50 messages
+```
+
+### Read thread replies
+
+```bash
+slack thread "C1234567890" "1234567890.123456"
+slack thread "C1234567890" "1234567890.123456" --json   # Raw JSON output
+```
+
+Thread timestamps (`ts`) come from search results or channel history.
+
+### List and view users
+
+```bash
+slack users
+slack user "U1234567890"
+```
+
+## Advanced: Direct API Access
+
+For operations not covered by `slack`, use `slack-api` (keeps token secure):
+
+```bash
+# Post with rich formatting (blocks)
+slack-api POST chat.postMessage '{"channel": "#general", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "*Bold* and _italic_"}}]}'
+
+# Add reaction
+slack-api POST reactions.add '{"channel": "C1234", "timestamp": "1234.5678", "name": "thumbsup"}'
+
+# Get user info
+slack-api GET "users.info?user=U1234567890"
+
+# Reply to thread
+slack-api POST chat.postMessage '{"channel": "C1234", "thread_ts": "1234.5678", "text": "Thread reply"}'
+```
+
+See [references/api.md](references/api.md) for more API patterns.
+
+## Permissions Included
+
+The manifest (`slack-setup`) includes these bot scopes:
+
+| Category | Scopes |
+|----------|--------|
+| Search | `search:read` |
+| Messaging | `chat:write`, `chat:write.public`, `reactions:read`, `reactions:write` |
+| Public channels | `channels:read`, `channels:history`, `channels:join` |
+| Private channels | `groups:read`, `groups:history` |
+| Direct messages | `im:read`, `im:write`, `im:history` |
+| Users | `users:read`, `users:read.email` |
+| Files | `files:read`, `files:write` |
+| Other | `emoji:read`, `links:read` |

--- a/tools/slack/manifest.yaml
+++ b/tools/slack/manifest.yaml
@@ -1,0 +1,28 @@
+display_information:
+  name: Letta Slack Integration
+  description: CLI tool for searching messages, reading threads, and sending notifications
+  background_color: "#2c2d30"
+oauth_config:
+  scopes:
+    # User token (xoxp-) - for search and acting as user
+    user:
+      - search:read
+      - channels:read
+      - channels:history
+      - groups:read
+      - groups:history
+      - im:read
+      - im:write
+      - im:history
+      - chat:write
+      - files:read
+      - files:write
+      - users:read
+      - users:read.email
+      - reactions:read
+      - reactions:write
+      - emoji:read
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/tools/slack/references/api.md
+++ b/tools/slack/references/api.md
@@ -1,0 +1,144 @@
+# Slack API Reference
+
+Common API patterns using the `slack-api` helper (keeps tokens secure).
+
+## Usage
+
+```bash
+slack-api POST <endpoint> '<json-body>'
+slack-api GET <endpoint>?<params>
+```
+
+## Message Formatting
+
+Slack uses **mrkdwn** (not standard markdown):
+- Bold: `*text*`
+- Italic: `_text_`
+- Strikethrough: `~text~`
+- Code: `` `code` ``
+- Code block: ``` ```code``` ```
+- Link: `<https://example.com|link text>`
+- User mention: `<@U1234567890>`
+- Channel mention: `<#C1234567890>`
+
+## Common API Calls
+
+### Messages
+
+```bash
+# Post message
+slack-api POST chat.postMessage '{"channel": "C1234", "text": "Hello"}'
+
+# Post with blocks (rich formatting)
+slack-api POST chat.postMessage '{"channel": "#general", "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "*Bold* and _italic_"}}]}'
+
+# Update message
+slack-api POST chat.update '{"channel": "C1234", "ts": "1234.5678", "text": "Updated"}'
+
+# Delete message
+slack-api POST chat.delete '{"channel": "C1234", "ts": "1234.5678"}'
+
+# Reply in thread
+slack-api POST chat.postMessage '{"channel": "C1234", "thread_ts": "1234.5678", "text": "Reply"}'
+```
+
+### Reactions
+
+```bash
+# Add reaction
+slack-api POST reactions.add '{"channel": "C1234", "timestamp": "1234.5678", "name": "thumbsup"}'
+
+# Remove reaction
+slack-api POST reactions.remove '{"channel": "C1234", "timestamp": "1234.5678", "name": "thumbsup"}'
+
+# Get reactions on a message
+slack-api GET "reactions.get?channel=C1234&timestamp=1234.5678"
+```
+
+### Files
+
+```bash
+# Note: File uploads require multipart form data, use curl directly with slack-api pattern
+# Upload text snippet
+slack-api POST files.upload '{"channels": "C1234", "content": "console.log(\"hello\")", "filetype": "javascript", "title": "code.js"}'
+
+# Get file info
+slack-api GET "files.info?file=F1234567890"
+
+# Delete file
+slack-api POST files.delete '{"file": "F1234567890"}'
+```
+
+### Channels
+
+```bash
+# Create channel
+slack-api POST conversations.create '{"name": "new-channel"}'
+
+# Invite user to channel
+slack-api POST conversations.invite '{"channel": "C1234", "users": "U5678"}'
+
+# Set channel topic
+slack-api POST conversations.setTopic '{"channel": "C1234", "topic": "New topic"}'
+
+# Archive channel
+slack-api POST conversations.archive '{"channel": "C1234"}'
+
+# Get channel info
+slack-api GET "conversations.info?channel=C1234"
+```
+
+### Users
+
+```bash
+# Get user info
+slack-api GET "users.info?user=U1234567890"
+
+# Get user by email
+slack-api GET "users.lookupByEmail?email=user@example.com"
+
+# List all users
+slack-api GET "users.list?limit=100"
+```
+
+### Search
+
+```bash
+# Search messages
+slack-api GET "search.messages?query=deployment&sort=timestamp&sort_dir=desc&count=20"
+
+# Search with modifiers
+slack-api GET "search.messages?query=from:@caren%20in:%23engineering%20after:2024-01-01"
+```
+
+**Search modifiers:**
+- `from:@username` - Messages from user
+- `in:#channel` - Messages in channel
+- `to:@username` - DMs to user
+- `has:link` - Messages with links
+- `has:reaction` - Messages with reactions
+- `before:2024-01-01` - Before date
+- `after:2024-01-01` - After date
+- `on:2024-01-01` - On specific date
+
+## Error Handling
+
+All Slack API responses include `ok` boolean:
+```json
+{"ok": true, "channel": "C1234", ...}
+{"ok": false, "error": "channel_not_found"}
+```
+
+Common errors:
+- `not_authed` - Missing or invalid token
+- `missing_scope` - Token lacks required scope
+- `channel_not_found` - Invalid channel ID
+- `user_not_found` - Invalid user ID
+- `ratelimited` - Too many requests
+
+## Rate Limits
+
+- Most methods: ~50 req/min
+- Search: ~20 req/min
+
+The `slack-api` helper doesn't handle rate limits automatically. For bulk operations, add delays between calls.

--- a/tools/slack/scripts/slack
+++ b/tools/slack/scripts/slack
@@ -1,0 +1,287 @@
+#!/bin/bash
+#
+# slack - A simple wrapper for common Slack API operations
+#
+# Prerequisites:
+#   export SLACK_TOKEN="xoxp-..."  # User token (recommended, supports search)
+#   # or: export SLACK_BOT_TOKEN="xoxb-..."  # Bot token (can't search)
+#
+# Usage:
+#   slack search "query"                    # Search messages
+#   slack send "#channel" "message"         # Send message to channel
+#   slack send "@user" "message"            # DM a user
+#   slack channels                          # List channels
+#   slack history "#channel" [limit]        # Get channel history
+#   slack thread "channel" "thread_ts"      # Get thread replies
+#   slack users                             # List users
+#   slack user "user_id"                    # Get user info
+
+set -euo pipefail
+
+# Show help before checking for token
+if [[ "${1:-}" == "help" || "${1:-}" == "--help" || "${1:-}" == "-h" || -z "${1:-}" ]]; then
+  cat <<EOF
+slack - Slack API wrapper
+
+Usage:
+  slack search "query"                 Search messages workspace-wide
+  slack send "#channel" "message"      Send message to channel
+  slack send "@user" "message"         Send DM to user
+  slack join "#channel"                Join a public channel
+  slack channels                       List public channels
+  slack history "#channel" [limit]     Get channel message history
+  slack thread "channel_id" "ts"       Get thread replies
+  slack users                          List workspace users
+  slack user "user_id"                 Get user details
+
+Environment:
+  SLACK_TOKEN        User token (xoxp-...) - recommended, supports search
+  SLACK_BOT_TOKEN    Bot token (xoxb-...) - fallback, cannot search
+
+Note: Search requires a user token (xoxp-). Bot tokens cannot search.
+EOF
+  exit 0
+fi
+
+SLACK_TOKEN="${SLACK_TOKEN:-${SLACK_BOT_TOKEN:-}}"
+
+if [[ -z "$SLACK_TOKEN" ]]; then
+  echo "Error: SLACK_TOKEN environment variable not set" >&2
+  echo "Set a user token (xoxp-...) for full functionality including search." >&2
+  exit 1
+fi
+
+API_BASE="https://slack.com/api"
+
+slack_api() {
+  local method="$1"
+  shift
+  curl -s -X POST "$API_BASE/$method" \
+    -H "Authorization: Bearer $SLACK_TOKEN" \
+    -H "Content-Type: application/json" \
+    "$@"
+}
+
+slack_api_get() {
+  local method="$1"
+  shift
+  curl -s -G "$API_BASE/$method" \
+    -H "Authorization: Bearer $SLACK_TOKEN" \
+    "$@"
+}
+
+case "${1:-help}" in
+  search)
+    # Search messages across the workspace
+    # Requires: search:read scope
+    query="${2:-}"
+    if [[ -z "$query" ]]; then
+      echo "Usage: slack search \"query\"" >&2
+      exit 1
+    fi
+    slack_api_get "search.messages" \
+      --data-urlencode "query=$query" \
+      --data-urlencode "sort=timestamp" \
+      --data-urlencode "sort_dir=desc" \
+      --data-urlencode "count=20" | jq -r '
+      if .ok then
+        .messages.matches[] | 
+        "[\(.channel.name // "DM")] \(.username // .user): \(.text | gsub("\n"; " ") | .[0:200])"
+      else
+        "Error: \(.error)"
+      end'
+    ;;
+
+  send)
+    # Send a message to a channel or user
+    # Requires: chat:write scope
+    target="${2:-}"
+    message="${3:-}"
+    if [[ -z "$target" || -z "$message" ]]; then
+      echo "Usage: slack send \"#channel\" \"message\"" >&2
+      echo "       slack send \"@user\" \"message\"" >&2
+      exit 1
+    fi
+    # Convert #channel to channel name, @user to user lookup
+    if [[ "$target" == "#"* ]]; then
+      channel="${target#\#}"
+    elif [[ "$target" == "@"* ]]; then
+      channel="${target#@}"
+    else
+      channel="$target"
+    fi
+    slack_api "chat.postMessage" \
+      -d "{\"channel\": \"$channel\", \"text\": \"$message\"}" | jq -r '
+      if .ok then
+        "Message sent to \(.channel)"
+      else
+        "Error: \(.error)"
+      end'
+    ;;
+
+  join)
+    # Join a public channel
+    # Requires: channels:join scope
+    channel="${2:-}"
+    if [[ -z "$channel" ]]; then
+      echo "Usage: slack join \"#channel\"" >&2
+      exit 1
+    fi
+    channel="${channel#\#}"
+    # Get channel ID first
+    channel_id=$(slack_api_get "conversations.list" \
+      --data-urlencode "types=public_channel" | \
+      jq -r ".channels[] | select(.name==\"$channel\") | .id")
+    if [[ -z "$channel_id" ]]; then
+      echo "Error: Channel #$channel not found" >&2
+      exit 1
+    fi
+    slack_api "conversations.join" \
+      -d "{\"channel\": \"$channel_id\"}" | jq -r '
+      if .ok then
+        "Joined #\(.channel.name)"
+      else
+        "Error: \(.error)"
+      end'
+    ;;
+
+  channels|list-channels)
+    # List public channels
+    # Requires: channels:read scope
+    slack_api_get "conversations.list" \
+      --data-urlencode "types=public_channel" \
+      --data-urlencode "limit=100" | jq -r '
+      if .ok then
+        .channels[] | "#\(.name) (\(.num_members) members) - \(.purpose.value // "No description" | .[0:60])"
+      else
+        "Error: \(.error)"
+      end'
+    ;;
+
+  history)
+    # Get channel history
+    # Requires: channels:history scope
+    channel="${2:-}"
+    limit="${3:-20}"
+    if [[ -z "$channel" ]]; then
+      echo "Usage: slack history \"#channel\" [limit]" >&2
+      exit 1
+    fi
+    channel="${channel#\#}"
+    # First get channel ID
+    channel_id=$(slack_api_get "conversations.list" \
+      --data-urlencode "types=public_channel,private_channel" | \
+      jq -r ".channels[] | select(.name==\"$channel\") | .id")
+    if [[ -z "$channel_id" ]]; then
+      echo "Error: Channel #$channel not found" >&2
+      exit 1
+    fi
+    slack_api_get "conversations.history" \
+      --data-urlencode "channel=$channel_id" \
+      --data-urlencode "limit=$limit" | jq -r '
+      if .ok then
+        .messages[] | 
+        "[\(.ts | tonumber | strftime("%Y-%m-%d %H:%M"))] \(.user // "bot"): \(.text | gsub("\n"; " ") | .[0:200])"
+      else
+        "Error: \(.error)"
+      end'
+    ;;
+
+  thread)
+    # Get thread replies
+    # Requires: channels:history scope
+    # Usage: slack thread <channel> <ts> [--json]
+    json_output=false
+    channel=""
+    thread_ts=""
+    for arg in "${@:2}"; do
+      case "$arg" in
+        --json) json_output=true ;;
+        *) [[ -z "$channel" ]] && channel="$arg" || thread_ts="$arg" ;;
+      esac
+    done
+    if [[ -z "$channel" || -z "$thread_ts" ]]; then
+      echo "Usage: slack thread \"channel_id\" \"thread_ts\" [--json]" >&2
+      exit 1
+    fi
+    if $json_output; then
+      slack_api_get "conversations.replies" \
+        --data-urlencode "channel=$channel" \
+        --data-urlencode "ts=$thread_ts"
+    else
+      slack_api_get "conversations.replies" \
+        --data-urlencode "channel=$channel" \
+        --data-urlencode "ts=$thread_ts" | jq -r '
+        if .ok then
+          "Thread: \(.messages | length) messages\n" + "="*60 + "\n" +
+          (.messages | to_entries | map(
+            "\n[\(.value.ts | tonumber | strftime("%Y-%m-%d %H:%M"))] @\(.value.user // "bot"):\n\(.value.text)\n" + "-"*60
+          ) | join("\n"))
+        else
+          "Error: \(.error)"
+        end'
+    fi
+    ;;
+
+  users)
+    # List workspace users
+    # Requires: users:read scope
+    slack_api_get "users.list" \
+      --data-urlencode "limit=100" | jq -r '
+      if .ok then
+        .members[] | select(.deleted == false and .is_bot == false) |
+        "@\(.name) - \(.real_name // "No name") (\(.profile.title // "No title"))"
+      else
+        "Error: \(.error)"
+      end'
+    ;;
+
+  user)
+    # Get user info
+    # Requires: users:read scope
+    user_id="${2:-}"
+    if [[ -z "$user_id" ]]; then
+      echo "Usage: slack user \"user_id\"" >&2
+      exit 1
+    fi
+    slack_api_get "users.info" \
+      --data-urlencode "user=$user_id" | jq -r '
+      if .ok then
+        .user | "Name: \(.real_name)\nUsername: @\(.name)\nTitle: \(.profile.title // "N/A")\nEmail: \(.profile.email // "N/A")"
+      else
+        "Error: \(.error)"
+      end'
+    ;;
+
+  help|--help|-h|"")
+    cat <<EOF
+slack - Slack API wrapper
+
+Usage:
+  slack search "query"                 Search messages workspace-wide
+  slack send "#channel" "message"      Send message to channel
+  slack send "@user" "message"         Send DM to user
+  slack channels                       List public channels
+  slack history "#channel" [limit]     Get channel message history
+  slack thread "channel_id" "ts"       Get thread replies
+  slack users                          List workspace users
+  slack user "user_id"                 Get user details
+
+Environment:
+  SLACK_BOT_TOKEN    Bot token (xoxb-...) with required scopes
+
+Required Bot Token Scopes:
+  search:read        For searching messages
+  chat:write         For sending messages
+  channels:read      For listing channels
+  channels:history   For reading channel history
+  users:read         For listing/viewing users
+EOF
+    ;;
+
+  *)
+    echo "Unknown command: $1" >&2
+    echo "Run 'slack help' for usage" >&2
+    exit 1
+    ;;
+esac

--- a/tools/slack/scripts/slack-api
+++ b/tools/slack/scripts/slack-api
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# slack-api - Make authenticated Slack API calls without exposing token
+#
+# Usage:
+#   slack-api POST chat.postMessage '{"channel": "#general", "text": "Hello"}'
+#   slack-api GET conversations.list
+#
+# The token is read from SLACK_BOT_TOKEN env var (never appears in command)
+
+set -euo pipefail
+
+SLACK_TOKEN="${SLACK_TOKEN:-${SLACK_BOT_TOKEN:-}}"
+
+if [[ -z "$SLACK_TOKEN" ]]; then
+  echo "Error: SLACK_TOKEN not set" >&2
+  exit 1
+fi
+
+method="${1:-GET}"
+endpoint="${2:-}"
+body="${3:-}"
+
+if [[ -z "$endpoint" ]]; then
+  echo "Usage: slack-api <GET|POST> <endpoint> [json-body]" >&2
+  echo "Example: slack-api POST chat.postMessage '{\"channel\": \"#general\", \"text\": \"Hi\"}'" >&2
+  exit 1
+fi
+
+if [[ "$method" == "POST" && -n "$body" ]]; then
+  curl -s -X POST "https://slack.com/api/$endpoint" \
+    -H "Authorization: Bearer $SLACK_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$body"
+elif [[ "$method" == "GET" ]]; then
+  curl -s "https://slack.com/api/$endpoint" \
+    -H "Authorization: Bearer $SLACK_TOKEN"
+else
+  curl -s -X "$method" "https://slack.com/api/$endpoint" \
+    -H "Authorization: Bearer $SLACK_TOKEN"
+fi

--- a/tools/slack/scripts/slack-setup
+++ b/tools/slack/scripts/slack-setup
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# slack-setup - Create a Slack app with the correct permissions
+#
+# Usage:
+#   slack-setup              # Opens browser to create Slack app
+#   slack-setup --manifest   # Print the manifest YAML
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST_PATH="$SCRIPT_DIR/../manifest.yaml"
+
+case "${1:-}" in
+  --manifest|-m)
+    cat "$MANIFEST_PATH"
+    ;;
+  --help|-h)
+    cat <<EOF
+slack-setup - Create a Slack app with pre-configured permissions
+
+Usage:
+  slack-setup              Opens browser to create Slack app with manifest
+  slack-setup --manifest   Print the manifest YAML
+
+After creating the app:
+  1. Click "Install to Workspace" and authorize
+  2. Copy the "Bot User OAuth Token" (starts with xoxb-)
+  3. Set it in your shell:
+     export SLACK_BOT_TOKEN="xoxb-..."
+  4. Test with: slack channels
+EOF
+    ;;
+  *)
+    if [[ ! -f "$MANIFEST_PATH" ]]; then
+      echo "Error: manifest.yaml not found at $MANIFEST_PATH" >&2
+      exit 1
+    fi
+
+    # URL-encode the manifest
+    manifest_encoded=$(python3 -c "import urllib.parse; print(urllib.parse.quote(open('$MANIFEST_PATH').read()))")
+    
+    url="https://api.slack.com/apps?new_app=1&manifest_yaml=$manifest_encoded"
+    
+    echo "Opening Slack app creation page..."
+    echo ""
+    echo "Next steps:"
+    echo "  1. Review the app configuration and click 'Create'"
+    echo "  2. Go to 'OAuth & Permissions' in the left sidebar"
+    echo "  3. Click 'Install to Workspace' and authorize"
+    echo "  4. Copy the 'Bot User OAuth Token' (xoxb-...)"
+    echo "  5. Run: export SLACK_BOT_TOKEN=\"xoxb-...\""
+    echo ""
+    
+    # Open browser (macOS)
+    if command -v open &> /dev/null; then
+      open "$url"
+    # Linux
+    elif command -v xdg-open &> /dev/null; then
+      xdg-open "$url"
+    else
+      echo "Open this URL in your browser:"
+      echo "$url"
+    fi
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds a Slack CLI tool for searching messages, reading threads, and sending notifications. Includes one-click setup via Slack's manifest URL feature.

## Features

- **Search**: Search messages across all channels (requires user token)
- **Send**: Send messages and thread replies
- **Channels**: List available channels
- **History**: Read channel message history
- **Thread**: Read full thread conversations
- **Users**: List workspace members
- **One-click setup**: Pre-configured manifest URL for quick app creation

## Key Details

**User Tokens vs Bot Tokens:**
- Uses user tokens (xoxp-) instead of bot tokens (xoxb-)
- Bot tokens **cannot** use Slack's `search.messages` API (platform limitation)
- User tokens provide full search + all bot capabilities

**Manifest-Based Setup:**
- `slack-setup` script generates pre-configured manifest URL
- Opens browser with all permissions already set
- User just clicks "Create" and installs to workspace
- Eliminates manual scope/event configuration

## Files

- `tools/slack/SKILL.md` - Complete documentation
- `tools/slack/manifest.yaml` - Slack app manifest (user scopes)
- `tools/slack/scripts/slack-setup` - One-click setup script
- `tools/slack/scripts/slack` - CLI wrapper for common operations
- `tools/slack/scripts/slack-api` - Direct API access helper
- `tools/slack/references/api.md` - API reference examples

## Usage

```bash
# Setup
export PATH="$PATH:~/.letta/skills/slack/scripts"
slack-setup  # Opens browser with pre-configured app
# Copy user token after installing
export SLACK_TOKEN="xoxp-..."

# Use
slack search "error logs"
slack send "#general" "Hello team"
slack channels
slack history "#general" --limit 10
```

## Test Plan

- [ ] Verify manifest URL generates correctly
- [ ] Test app creation via manifest
- [ ] Confirm user token search functionality
- [ ] Test all CLI commands (search, send, channels, history, thread, users)

👾 Generated with [Letta Code](https://letta.com)