### PR TITLE
Add: tools/linear - Linear issue management skill

### DIFF
--- a/tools/linear/SKILL.md
+++ b/tools/linear/SKILL.md
@@ -7,6 +7,13 @@ description: Manage Linear issues via GraphQL API. List, filter, update, priorit
 
 Interact with Linear's GraphQL API to manage issues.
 
+## When to Use
+
+- User asks about Linear issues, tickets, or project management
+- Need to triage, prioritize, or update issue status
+- Want to search or comment on issues
+- Managing a backlog or sprint
+
 ## Setup
 
 Requires `LINEAR_API_KEY` environment variable. Get one from Linear Settings > API > Personal API keys.

--- a/tools/linear/scripts/linear.ts
+++ b/tools/linear/scripts/linear.ts
@@ -7,12 +7,27 @@
 const LINEAR_API = "https://api.linear.app/graphql";
 const API_KEY = process.env.LINEAR_API_KEY;
 
+// Type definitions
+interface GraphQLError {
+  message: string;
+}
+
+interface WorkflowState {
+  id: string;
+  name: string;
+}
+
+interface IssueUpdateInput {
+  priority?: number;
+  stateId?: string;
+}
+
 if (!API_KEY) {
   console.error("Error: LINEAR_API_KEY environment variable not set");
   process.exit(1);
 }
 
-async function graphql(query: string, variables: Record<string, any> = {}) {
+async function graphql(query: string, variables: Record<string, unknown> = {}) {
   const res = await fetch(LINEAR_API, {
     method: "POST",
     headers: {
@@ -23,7 +38,7 @@ async function graphql(query: string, variables: Record<string, any> = {}) {
   });
   const data = await res.json();
   if (data.errors) {
-    throw new Error(data.errors.map((e: any) => e.message).join(", "));
+    throw new Error(data.errors.map((e: GraphQLError) => e.message).join(", "));
   }
   return data.data;
 }
@@ -131,7 +146,7 @@ async function updateIssue(id: string, updates: { priority?: number; state?: str
     throw new Error(`Issue not found: ${id}`);
   }
 
-  const input: Record<string, any> = {};
+  const input: IssueUpdateInput = {};
   
   if (updates.priority !== undefined) {
     input.priority = updates.priority;
@@ -151,7 +166,7 @@ async function updateIssue(id: string, updates: { priority?: number; state?: str
     `;
     const statesData = await graphql(statesQuery);
     const state = statesData.workflowStates.nodes.find(
-      (s: any) => s.name.toLowerCase() === updates.state!.toLowerCase()
+      (s: WorkflowState) => s.name.toLowerCase() === updates.state!.toLowerCase()
     );
     if (!state) {
       throw new Error(`State not found: ${updates.state}`);


### PR DESCRIPTION
## Add: tools/linear

Adds a skill for managing Linear issues via GraphQL API.

**What:** A CLI tool and skill documentation for interacting with Linear's GraphQL API.

**Features:**
- List issues with state/assignee filters
- Get issue details with comments  
- Update priority and state
- Add comments to issues
- Search issues

**Why:** Linear is widely used for project management. This skill captures battle-tested patterns for working with Linear's GraphQL API that go beyond official docs:
- Query filter syntax quirks
- State ID lookup pattern for mutations
- Issue ID vs identifier handling

**Source:** Built through hands-on use managing Ezra Support triage queue.

**Testing:** Validated against live Linear instance with real triage workflows.

🐧 Generated with [Letta Code](https://letta.com)