### PR TITLE
Add: tools/obsidian-cli

### DIFF
--- a/tools/obsidian-cli/SKILL.md
+++ b/tools/obsidian-cli/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: obsidian-cli
+description: Work with Obsidian vaults using the official Obsidian CLI. Read, create, append, search, and manage notes, daily notes, properties, tags, tasks, sync, and more from the terminal. Use when the user mentions Obsidian, notes, vault, daily notes, or when working with markdown knowledge bases. Requires Obsidian desktop app running with CLI enabled in Settings > General.
+---
+
+# Obsidian CLI
+
+Official Obsidian CLI for terminal vault operations. Requires Obsidian running (headless via xvfb works) with CLI enabled and insider/early access mode.
+
+All parameters use `key=value` syntax: `obsidian read path="folder/note.md"`. On headless Linux, prefix with `DISPLAY=:5` (or whatever your xvfb display is).
+
+## Core Commands
+
+### Daily Notes
+
+```bash
+obsidian daily                           # Open today's daily note
+obsidian daily:read                      # Print today's note content
+obsidian daily:append content="text"     # Append to today's note
+obsidian daily:prepend content="text"    # Prepend to today's note
+```
+
+### Reading and Writing Files
+
+```bash
+obsidian read path="folder/note.md"                          # Read note
+obsidian create path="folder/note" content="# Title"         # Create note (path without .md)
+obsidian create path="folder/note" template="templatename"    # Create from template
+obsidian append path="folder/note.md" content="text"          # Append to note
+obsidian prepend path="folder/note.md" content="text"         # Prepend to note
+obsidian move path="old/note.md" name="new-name"              # Move/rename
+obsidian delete path="folder/note.md"                         # Delete (to trash)
+obsidian delete path="folder/note.md" permanent               # Permanent delete
+```
+
+### File Discovery
+
+```bash
+obsidian files                      # List all files
+obsidian files ext=md               # Only markdown files
+obsidian files folder="subfolder"   # Files in specific folder
+obsidian files total                # Just the count
+obsidian folders                    # List all folders
+obsidian file path="folder/note.md" # File info (size, dates)
+```
+
+### Search
+
+```bash
+obsidian search query="search text"                    # Search vault
+obsidian search query="text" path="folder" limit=10    # Scoped search
+obsidian search query="text" format=json               # JSON output
+obsidian search query="text" matches                   # Show match context
+obsidian search query="text" case                      # Case-sensitive
+```
+
+### Links and Graph
+
+```bash
+obsidian backlinks path="note.md"      # Backlinks to a note
+obsidian backlinks path="note.md" counts  # With link counts
+obsidian links path="note.md"          # Outgoing links (requires plugin)
+obsidian unresolved                    # Unresolved [[links]]
+obsidian orphans                       # Notes with no links in or out
+obsidian deadends                      # Notes with no outgoing links
+```
+
+### Properties (Frontmatter)
+
+```bash
+obsidian properties path="note.md"                          # All properties
+obsidian property:read path="note.md" name="status"         # Read one property
+obsidian property:set path="note.md" name="status" value="draft"  # Set property
+obsidian property:remove path="note.md" name="status"       # Remove property
+obsidian aliases path="note.md"                             # List aliases
+```
+
+### Tags
+
+```bash
+obsidian tags                          # All tags
+obsidian tags counts sort=count        # Tags sorted by frequency
+obsidian tags path="note.md"           # Tags in specific file
+obsidian tag name="tagname"            # Notes with specific tag
+```
+
+### Tasks
+
+```bash
+obsidian tasks                              # All incomplete tasks
+obsidian tasks all                          # All tasks (done + todo)
+obsidian tasks done                         # Only completed tasks
+obsidian tasks path="note.md"               # Tasks in specific file
+obsidian tasks daily                        # Tasks in today's daily note
+obsidian task path="note.md" line=5 toggle  # Toggle task status
+```
+
+### Sync
+
+```bash
+obsidian sync                                  # Show sync status
+obsidian sync on                               # Resume sync
+obsidian sync off                              # Pause sync
+obsidian sync:status                           # Detailed status
+obsidian sync:history path="note.md"           # Version history
+obsidian sync:read path="note.md" version=3    # Read specific version
+obsidian sync:restore path="note.md" version=3 # Restore version
+obsidian sync:deleted                          # Deleted files in sync
+```
+
+### Templates
+
+```bash
+obsidian templates                          # List templates
+obsidian template:read name="weekly-review" # Read template content
+obsidian template:read name="weekly-review" resolve title="My Note"  # Render with variables
+obsidian template:insert name="weekly-review"  # Insert into active file
+```
+
+### Other Useful Commands
+
+```bash
+obsidian vault                         # Vault info (name, path, file count, size)
+obsidian vaults                        # List all known vaults
+obsidian outline path="note.md"        # Heading structure
+obsidian wordcount path="note.md"      # Word/character count
+obsidian recents                       # Recently opened files
+obsidian version                       # Obsidian version
+obsidian reload                        # Reload vault
+```
+
+### Plugins
+
+```bash
+obsidian plugins                    # List all plugins
+obsidian plugins:enabled            # List enabled plugins
+obsidian plugin:enable id="canvas"  # Enable plugin
+obsidian plugin:disable id="canvas" # Disable plugin
+obsidian plugin:install id="name"   # Install from community
+obsidian plugin:reload id="name"    # Reload plugin
+```
+
+### Developer Commands
+
+```bash
+obsidian dev:screenshot path="screenshot.png"   # Screenshot
+obsidian eval code="app.vault.getFiles().length" # Run JS in Obsidian
+obsidian dev:console limit=20                    # Recent console output
+obsidian dev:errors                              # Recent errors
+```
+
+## Common Agent Patterns
+
+### Append to Daily Note with Linking
+
+```bash
+obsidian daily:append content="
+## Reports
+- [[reports/2026-02-10-morning|Morning Report]]
+"
+```
+
+### Create Note and Cross-Link
+
+```bash
+obsidian create path="reports/morning-report" content="# Morning Report"
+obsidian daily:append content="- [[reports/morning-report|Morning Report]]"
+```
+
+### Set Properties Programmatically
+
+```bash
+obsidian property:set path="note.md" name="status" value="draft"
+obsidian property:set path="note.md" name="date" value="2026-02-10"
+```
+
+## Setup
+
+### Requirements
+- Obsidian desktop app installed and running (v1.12.0+ with insider/early access)
+- CLI enabled: Settings > General > CLI toggle
+- `insider` and `cli` set to `true` in global config (`~/.config/obsidian/obsidian.json` on Linux, `~/Library/Application Support/obsidian/obsidian.json` on macOS)
+
+### Headless Linux
+Use deb package (not snap - snap confinement breaks CLI IPC). Run under xvfb. See references/headless-setup.md for config transfer details.
+
+### Multi-Vault
+Use `vault="Vault Name"` parameter: `obsidian vault="Notes" daily:read`
+
+## Tips
+
+1. **Parameter syntax**: Always `key=value`, not positional. Quote values with spaces: `content="hello world"`
+2. **Pipe-friendly**: Plain text output, works with grep/awk/jq
+3. **JSON output**: `format=json` on search and other commands
+4. **Headless prefix**: `DISPLAY=:5 obsidian <command>` on headless Linux
+5. **Paths are vault-relative**, not filesystem-relative
+6. **Stderr noise**: GPU errors on headless are harmless, filter with `2>/dev/null` or grep

--- a/tools/obsidian-cli/references/headless-setup.md
+++ b/tools/obsidian-cli/references/headless-setup.md
@@ -1,0 +1,76 @@
+# Headless Obsidian CLI Setup
+
+## Critical: Use deb package, NOT snap
+
+Snap confinement creates separate filesystem namespaces. The CLI process and the running Obsidian instance end up with different `SingletonLock`/`SingletonSocket` paths, so CLI can't connect via IPC. The deb package avoids this entirely.
+
+```bash
+# Remove snap if installed
+sudo snap remove obsidian
+
+# Install deb
+wget https://github.com/obsidianmd/obsidian-releases/releases/download/v1.11.7/obsidian_1.11.7_amd64.deb
+sudo dpkg -i obsidian_1.11.7_amd64.deb
+```
+
+## Enable CLI via Config
+
+CLI requires `insider` (early access) and `cli` flags in the global config. Enable from a local machine with UI access, then copy to the server.
+
+### Config locations
+- **Linux**: `~/.config/obsidian/obsidian.json`
+- **macOS**: `~/Library/Application Support/obsidian/obsidian.json`
+
+### Required entries
+```json
+{
+  "vaults": { ... },
+  "insider": true,
+  "cli": true
+}
+```
+
+The `insider` flag enables early access features. The `cli` flag enables the CLI. Both are set when you toggle CLI on in Settings > General on a machine with UI access.
+
+## Running Headless
+
+### Prerequisites
+```bash
+sudo apt install xvfb
+```
+
+### Start xvfb (if not already running)
+```bash
+Xvfb :5 -extension GLX -screen 0 800x600x16 &
+```
+
+### Start Obsidian
+```bash
+DISPLAY=:5 nohup obsidian --no-sandbox --disable-gpu --disable-software-rasterizer --in-process-gpu > /tmp/obsidian.log 2>&1 &
+```
+
+The `--disable-gpu` and related flags prevent GPU initialization crashes on headless servers. GPU errors in stderr are harmless and can be ignored.
+
+### Auto-update
+On first launch with `insider: true`, Obsidian will download the latest insider .asar to `~/.config/obsidian/obsidian-<version>.asar` and load it on subsequent starts.
+
+## Using CLI
+
+```bash
+DISPLAY=:5 obsidian daily:read
+DISPLAY=:5 obsidian search query="meeting notes" limit=5
+```
+
+The `DISPLAY` variable is needed because the CLI process briefly initializes Electron (even for IPC). Filter stderr noise:
+
+```bash
+DISPLAY=:5 obsidian daily:read 2>/dev/null
+```
+
+## Verification
+
+```bash
+DISPLAY=:5 obsidian version          # Should print version
+DISPLAY=:5 obsidian vault            # Should show vault info
+DISPLAY=:5 obsidian daily:read       # Should print daily note
+```


### PR DESCRIPTION
## Summary
- Adds `obsidian-cli` skill for terminal vault operations via the official Obsidian CLI (v1.12.0+, insider/early access)
- Full command reference with tested `key=value` parameter syntax
- Headless Linux setup guide with snap vs deb gotcha

## Why
Obsidian just released an official CLI. This skill gives agents native vault access: reading/writing notes, managing daily notes, searching, setting properties, checking sync status, and more. Replaces hacky workarounds (direct file manipulation, xdotool, REST API plugins).

## Source
Built from `obsidian help` output and hands-on testing on headless Linux. Discovered that snap confinement creates separate singleton socket paths, breaking CLI IPC. Documented deb package as the solution.

## Testing
15+ commands validated against a live 788-file vault on headless Ubuntu:
- Read/write: `daily:read`, `daily:append`, `read`, `create`, `append`, `delete`
- Metadata: `property:set`, `property:read`, `tags`, `wordcount`, `outline`
- Discovery: `vault`, `files`, `folders`, `search`, `backlinks`, `recents`
- System: `version`, `plugins:enabled`, `sync:status`

Full CRUD lifecycle tested (create, read, property set, append, delete).

## Attribution
Built by Co (agent) with Cameron Pfiffer.

🤖 Generated with [Letta Code](https://letta.com)