### PR TITLE
Add: tools/ai-news - fetch AI news from RSS feeds and YouTube transcripts

### DIFF
--- a/tools/ai-news/SKILL.md
+++ b/tools/ai-news/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ai-news
+description: Fetch and summarize recent AI news from curated RSS feeds (Hugging Face, VentureBeat, The Verge, OpenAI, Anthropic, DeepMind, etc.) and YouTube channels (Yannic Kilcher, Two Minute Papers, AI Explained, etc.). Also fetches full transcripts for specific YouTube videos. Use when the user asks about recent AI news, what's happened in AI lately, summaries of AI research or product announcements, or wants a digest of what's going on in the AI space.
+---
+
+# AI News
+
+Fetch recent AI news from RSS feeds and YouTube channel feeds, then synthesize into a digest. Optionally fetch full transcripts for YouTube videos.
+
+## Setup (one-time)
+
+```bash
+cd ~/.letta/skills/ai-news/scripts && npm install
+```
+
+## Workflow
+
+### 1. Fetch recent news
+
+```bash
+npx tsx scripts/fetch-news.ts [--days 7] [--limit 5] [--sources all|rss|youtube]
+```
+
+- Outputs a JSON object with `items[]` sorted newest-first
+- Each item has: `source`, `type` (rss/youtube), `title`, `url`, `publishedAt`, `summary`, `videoId`
+- Failed sources are listed in `errors[]` — safe to ignore individual failures
+
+### 2. Synthesize a digest
+
+Read the JSON output and write a digest grouped by theme (e.g. model releases, research, tools, policy). Lead with the most significant items. For YouTube videos, note they have transcripts available.
+
+### 3. (Optional) Fetch a video transcript
+
+For any YouTube item worth deeper coverage:
+
+```bash
+npx tsx scripts/fetch-transcript.ts <video-url-or-id> [--summary] [--lang en]
+```
+
+- `--summary` returns first ~4000 chars (good for quick context)
+- Without `--summary`, returns full transcript + timestamped segments
+- Works with any YouTube URL format or bare video ID
+
+## Customizing Sources
+
+See `references/sources.md` for the full list of default RSS feeds and YouTube channels, how to find channel IDs, and additional feed recommendations.
+
+To add/remove sources, edit the `RSS_FEEDS` and `YOUTUBE_CHANNELS` arrays at the top of `scripts/fetch-news.ts`.
+
+## Tips
+
+- Use `--days 1` for daily briefings, `--days 7` for weekly digests
+- Use `--sources rss` if YouTube fetches are slow or failing
+- Some feeds (arXiv) can be very high volume — use a lower `--limit` or filter by keyword after fetching
+- Transcripts require captions to be enabled on the video; auto-generated captions work fine

--- a/tools/ai-news/references/sources.md
+++ b/tools/ai-news/references/sources.md
@@ -1,0 +1,55 @@
+# AI News Sources
+
+This file documents the default sources used by the `ai-news` skill. Edit `fetch-news.ts` to add, remove, or swap sources.
+
+## RSS Feeds
+
+| Name | URL | Notes |
+|------|-----|-------|
+| Hugging Face Blog | https://huggingface.co/blog/feed.xml | Model releases, research, tutorials |
+| VentureBeat AI | https://venturebeat.com/category/ai/feed/ | Industry news, funding, products |
+| The Verge AI | https://www.theverge.com/rss/ai-artificial-intelligence/index.xml | Consumer AI, policy, culture |
+| MIT Tech Review AI | https://www.technologyreview.com/feed/ | Research-leaning tech journalism |
+| Ars Technica AI | https://feeds.arstechnica.com/arstechnica/index | Technical depth, policy |
+| OpenAI Blog | https://openai.com/blog/rss/ | First-party OpenAI announcements |
+| Google DeepMind Blog | https://deepmind.google/blog/rss.xml | First-party DeepMind research |
+| Anthropic News | https://www.anthropic.com/rss.xml | First-party Anthropic announcements |
+
+### Adding More RSS Feeds
+
+Any standard RSS/Atom feed URL works. Good candidates:
+- `https://arxiv.org/rss/cs.AI` — arXiv CS.AI preprints (high volume)
+- `https://arxiv.org/rss/cs.LG` — arXiv Machine Learning
+- `https://www.import.ai/feed` — Jack Clark's Import AI newsletter
+- `https://lastweekin.ai/feed` — Last Week in AI recap
+
+## YouTube Channels
+
+Fetched via YouTube's public channel RSS feed (no API key required):
+`https://www.youtube.com/feeds/videos.xml?channel_id=CHANNEL_ID`
+
+| Name | Channel ID | Focus |
+|------|-----------|-------|
+| Yannic Kilcher | UCZHmQk67mSJgfCCTn7xBfew | Paper walkthroughs, ML research deep dives |
+| Two Minute Papers | UCbfYPyITQ-7l4upoX8nvctg | Research paper summaries |
+| AI Explained | UCNJ1Ymd5yFuUPtn21xtRbbw | Accessible AI news and model breakdowns |
+| Matthew Berman | UCQgB5j8JONFTGRlCyxgUoqw | AI tools, product launches, demos |
+| Andrej Karpathy | UCXUPKJO5MZQRRJECM5OI9ZA | Deep technical ML education |
+
+### Finding Channel IDs
+
+To find a channel's ID:
+1. Go to the channel page on YouTube
+2. View page source and search for `"channelId"`
+3. Or use: `https://www.youtube.com/@handle` → check the URL after redirect, or use a tool like `https://commentpicker.com/youtube-channel-id.php`
+
+## Transcript Availability
+
+YouTube transcripts are fetched via `fetch-transcript.ts`. They are available when:
+- The video has auto-generated captions (most English videos do)
+- The creator has uploaded manual captions
+
+Transcripts are NOT available for:
+- Live streams (until archived)
+- Shorts (usually)
+- Videos where the creator has disabled captions

--- a/tools/ai-news/scripts/.gitignore
+++ b/tools/ai-news/scripts/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/tools/ai-news/scripts/fetch-news.ts
+++ b/tools/ai-news/scripts/fetch-news.ts
@@ -1,0 +1,230 @@
+#!/usr/bin/env npx tsx
+/**
+ * fetch-news.ts — Fetch recent AI news from RSS feeds and YouTube channel feeds.
+ *
+ * Usage:
+ *   npx tsx fetch-news.ts [--limit N] [--days N] [--sources rss|youtube|all]
+ *
+ * Options:
+ *   --limit N       Max items per source (default: 5)
+ *   --days N        Only include items from the last N days (default: 7)
+ *   --sources TYPE  Which sources to fetch: rss, youtube, or all (default: all)
+ *
+ * Output: JSON array of news items to stdout
+ */
+
+// ── Default sources ────────────────────────────────────────────────────────────
+
+const RSS_FEEDS = [
+  { name: "Hugging Face Blog",    url: "https://huggingface.co/blog/feed.xml" },
+  { name: "VentureBeat AI",       url: "https://venturebeat.com/category/ai/feed/" },
+  { name: "The Verge AI",         url: "https://www.theverge.com/rss/ai-artificial-intelligence/index.xml" },
+  { name: "MIT Tech Review AI",   url: "https://www.technologyreview.com/feed/" },
+  { name: "Ars Technica AI",      url: "https://feeds.arstechnica.com/arstechnica/index" },
+  { name: "OpenAI Blog",          url: "https://openai.com/blog/rss/" },
+  { name: "Google DeepMind Blog", url: "https://deepmind.google/blog/rss.xml" },
+  { name: "Anthropic News",       url: "https://www.anthropic.com/rss.xml" },
+];
+
+// YouTube channel IDs — channel RSS requires no API key
+const YOUTUBE_CHANNELS = [
+  { name: "Yannic Kilcher",    channelId: "UCZHmQk67mSJgfCCTn7xBfew" },
+  { name: "Two Minute Papers", channelId: "UCbfYPyITQ-7l4upoX8nvctg" },
+  { name: "AI Explained",      channelId: "UCNJ1Ymd5yFuUPtn21xtRbbw" },
+  { name: "Matthew Berman",    channelId: "UCQgB5j8JONFTGRlCyxgUoqw" },
+  { name: "Andrej Karpathy",   channelId: "UCXUPKJO5MZQRRJECM5OI9ZA" },
+];
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface NewsItem {
+  source: string;
+  type: "rss" | "youtube";
+  title: string;
+  url: string;
+  publishedAt: string;
+  summary?: string;
+  videoId?: string;
+}
+
+// ── XML helpers ────────────────────────────────────────────────────────────────
+
+function extractTag(xml: string, tag: string): string {
+  // Handle both <tag>content</tag> and CDATA
+  const patterns = [
+    new RegExp(`<${tag}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]><\\/${tag}>`, "i"),
+    new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i"),
+  ];
+  for (const re of patterns) {
+    const m = xml.match(re);
+    if (m) return m[1].trim();
+  }
+  return "";
+}
+
+function extractAttr(xml: string, tag: string, attr: string): string {
+  const re = new RegExp(`<${tag}[^>]*\\s${attr}="([^"]*)"`, "i");
+  const m = xml.match(re);
+  return m ? m[1] : "";
+}
+
+function splitItems(xml: string, itemTag: string): string[] {
+  const items: string[] = [];
+  const re = new RegExp(`<${itemTag}[\\s>][\\s\\S]*?<\\/${itemTag}>`, "gi");
+  let match;
+  while ((match = re.exec(xml)) !== null) {
+    items.push(match[0]);
+  }
+  return items;
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]+>/g, "").replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/\s+/g, " ").trim();
+}
+
+// ── Fetch helpers ──────────────────────────────────────────────────────────────
+
+async function fetchXml(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: { "User-Agent": "Mozilla/5.0 (compatible; ai-news-fetcher/1.0)" },
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return res.text();
+}
+
+// ── RSS parser ─────────────────────────────────────────────────────────────────
+
+async function fetchRssFeed(source: { name: string; url: string }, limit: number, cutoff: Date): Promise<NewsItem[]> {
+  const xml = await fetchXml(source.url);
+
+  // Try RSS <item> and Atom <entry>
+  const rawItems = splitItems(xml, "item").length > 0 ? splitItems(xml, "item") : splitItems(xml, "entry");
+
+  const items: NewsItem[] = [];
+  for (const raw of rawItems.slice(0, limit * 2)) {
+    const title = stripHtml(extractTag(raw, "title"));
+    const url =
+      extractTag(raw, "link") ||
+      extractAttr(raw, "link", "href") ||
+      extractTag(raw, "url");
+    const pubDate =
+      extractTag(raw, "pubDate") ||
+      extractTag(raw, "published") ||
+      extractTag(raw, "updated") ||
+      extractTag(raw, "dc:date");
+    const descRaw = extractTag(raw, "description") || extractTag(raw, "summary") || extractTag(raw, "content");
+    const summary = stripHtml(descRaw).slice(0, 300);
+
+    if (!title || !url) continue;
+
+    const date = pubDate ? new Date(pubDate) : new Date();
+    if (date < cutoff) continue;
+
+    items.push({
+      source: source.name,
+      type: "rss",
+      title,
+      url: url.trim(),
+      publishedAt: date.toISOString(),
+      summary: summary || undefined,
+    });
+
+    if (items.length >= limit) break;
+  }
+
+  return items;
+}
+
+// ── YouTube channel RSS ────────────────────────────────────────────────────────
+
+async function fetchYouTubeChannel(channel: { name: string; channelId: string }, limit: number, cutoff: Date): Promise<NewsItem[]> {
+  const feedUrl = `https://www.youtube.com/feeds/videos.xml?channel_id=${channel.channelId}`;
+  const xml = await fetchXml(feedUrl);
+
+  const entries = splitItems(xml, "entry");
+  const items: NewsItem[] = [];
+
+  for (const raw of entries.slice(0, limit * 2)) {
+    const title = stripHtml(extractTag(raw, "title"));
+    const videoId = extractTag(raw, "yt:videoId") || extractAttr(raw, "link", "href").match(/v=([^&]+)/)?.[1] || "";
+    const url = videoId ? `https://www.youtube.com/watch?v=${videoId}` : extractAttr(raw, "link", "href");
+    const published = extractTag(raw, "published");
+    const summary = stripHtml(extractTag(raw, "media:description") || extractTag(raw, "summary")).slice(0, 300);
+
+    if (!title || !url) continue;
+
+    const date = published ? new Date(published) : new Date();
+    if (date < cutoff) continue;
+
+    items.push({
+      source: channel.name,
+      type: "youtube",
+      title,
+      url,
+      publishedAt: date.toISOString(),
+      summary: summary || undefined,
+      videoId: videoId || undefined,
+    });
+
+    if (items.length >= limit) break;
+  }
+
+  return items;
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+let limit = 5;
+let days = 7;
+let sourcesFilter: "rss" | "youtube" | "all" = "all";
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--limit" && args[i + 1]) limit = parseInt(args[++i]);
+  else if (args[i] === "--days" && args[i + 1]) days = parseInt(args[++i]);
+  else if (args[i] === "--sources" && args[i + 1]) sourcesFilter = args[++i] as typeof sourcesFilter;
+}
+
+const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+async function main() {
+  const results: NewsItem[] = [];
+  const errors: string[] = [];
+
+  const rssTasks = sourcesFilter !== "youtube"
+    ? RSS_FEEDS.map(feed =>
+        fetchRssFeed(feed, limit, cutoff)
+          .then(items => results.push(...items))
+          .catch(e => errors.push(`${feed.name}: ${e.message}`))
+      )
+    : [];
+
+  const ytTasks = sourcesFilter !== "rss"
+    ? YOUTUBE_CHANNELS.map(ch =>
+        fetchYouTubeChannel(ch, limit, cutoff)
+          .then(items => results.push(...items))
+          .catch(e => errors.push(`${ch.name}: ${e.message}`))
+      )
+    : [];
+
+  await Promise.all([...rssTasks, ...ytTasks]);
+
+  // Sort by date descending
+  results.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+
+  const output = {
+    fetchedAt: new Date().toISOString(),
+    cutoffDate: cutoff.toISOString(),
+    totalItems: results.length,
+    errors: errors.length > 0 ? errors : undefined,
+    items: results,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch(e => {
+  console.error("Fatal error:", e.message);
+  process.exit(1);
+});

--- a/tools/ai-news/scripts/fetch-transcript.ts
+++ b/tools/ai-news/scripts/fetch-transcript.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env npx tsx
+/**
+ * fetch-transcript.ts — Fetch the transcript for a YouTube video.
+ *
+ * Usage:
+ *   npx tsx fetch-transcript.ts <video-url-or-id> [--lang en] [--summary]
+ *
+ * Arguments:
+ *   video-url-or-id   YouTube URL (any format) or bare video ID (e.g. dQw4w9WgXcQ)
+ *
+ * Options:
+ *   --lang CODE   Language code for transcript (default: en)
+ *   --summary     Print a condensed version (first 4000 chars) instead of full transcript
+ *
+ * Output: JSON with video metadata and full transcript text
+ *
+ * Requires: npm install (run once in this directory to install youtube-transcript)
+ */
+
+const { YoutubeTranscript } = require("./node_modules/youtube-transcript/dist/youtube-transcript.common.js");
+
+function extractVideoId(input: string): string {
+  if (/^[a-zA-Z0-9_-]{11}$/.test(input)) return input;
+  const patterns = [
+    /[?&]v=([a-zA-Z0-9_-]{11})/,
+    /youtu\.be\/([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+  ];
+  for (const re of patterns) {
+    const m = input.match(re);
+    if (m) return m[1];
+  }
+  throw new Error(`Could not extract video ID from: ${input}`);
+}
+
+function formatTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+if (args.length === 0 || args[0] === "--help") {
+  console.log(`Usage: npx tsx fetch-transcript.ts <video-url-or-id> [--lang en] [--summary]`);
+  process.exit(0);
+}
+
+const input = args[0];
+let lang = "en";
+let summaryMode = false;
+
+for (let i = 1; i < args.length; i++) {
+  if (args[i] === "--lang" && args[i + 1]) lang = args[++i];
+  else if (args[i] === "--summary") summaryMode = true;
+}
+
+async function main() {
+  const videoId = extractVideoId(input);
+
+  let segments: Array<{ text: string; offset: number; duration: number; lang: string }>;
+  try {
+    segments = await YoutubeTranscript.fetchTranscript(videoId, { lang });
+  } catch (e: any) {
+    throw new Error(`Could not fetch transcript: ${e.message}. The video may have captions disabled or the language '${lang}' may not be available.`);
+  }
+
+  const fullText = segments.map(s => s.text.replace(/\n/g, " ").trim()).join(" ");
+  const durationMs = segments.length > 0 ? segments[segments.length - 1].offset + segments[segments.length - 1].duration : 0;
+
+  if (summaryMode) {
+    const output = {
+      videoId,
+      url: `https://www.youtube.com/watch?v=${videoId}`,
+      language: lang,
+      segmentCount: segments.length,
+      durationSeconds: Math.round(durationMs / 1000),
+      transcript: fullText.slice(0, 4000) + (fullText.length > 4000 ? "... [truncated]" : ""),
+    };
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    const output = {
+      videoId,
+      url: `https://www.youtube.com/watch?v=${videoId}`,
+      language: lang,
+      segmentCount: segments.length,
+      durationSeconds: Math.round(durationMs / 1000),
+      transcript: fullText,
+      segments: segments.map(s => ({
+        time: formatTime(s.offset),
+        text: s.text.replace(/\n/g, " ").trim(),
+      })),
+    };
+    console.log(JSON.stringify(output, null, 2));
+  }
+}
+
+main().catch(e => {
+  console.error(JSON.stringify({ error: e.message, input }, null, 2));
+  process.exit(1);
+});

--- a/tools/ai-news/scripts/package.json
+++ b/tools/ai-news/scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ai-news-scripts",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "dependencies": {
+    "youtube-transcript": "^1.2.1"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new `tools/ai-news` skill for fetching recent AI news from curated RSS feeds and YouTube channel feeds
- Includes a `fetch-transcript.ts` script for pulling full transcripts from individual YouTube videos (uses `youtube-transcript` npm package)
- Ships with a `references/sources.md` documenting all default sources and how to customize them

## Sources included

**RSS feeds:** Hugging Face Blog, VentureBeat AI, The Verge AI, MIT Tech Review, Ars Technica, OpenAI Blog, Google DeepMind Blog, Anthropic News

**YouTube channels:** Yannic Kilcher, Two Minute Papers, AI Explained, Matthew Berman, Andrej Karpathy

## Usage

```bash
# One-time setup
cd tools/ai-news/scripts && npm install

# Fetch last 7 days of AI news (JSON)
npx tsx scripts/fetch-news.ts --days 7 --limit 5

# Fetch transcript for a specific YouTube video
npx tsx scripts/fetch-transcript.ts "https://youtu.be/VIDEO_ID" --summary
```

## Test plan

- [x] `fetch-news.ts` tested — successfully fetches from RSS and YouTube channel feeds
- [x] `fetch-transcript.ts` tested — successfully fetches transcripts via `youtube-transcript` package
- [x] `node_modules` excluded via `.gitignore`

👾 Generated with [Letta Code](https://letta.com)