### PR TITLE
Add: development/git/bare-repo-workspaces skill

### DIFF
--- a/development/git/bare-repo-workspaces/SKILL.md
+++ b/development/git/bare-repo-workspaces/SKILL.md
@@ -1,0 +1,511 @@
+---
+name: bare-repo-workspaces
+description: Git worktree operations using Worktrunk (wt). LOAD THIS SKILL whenever the user mentions "worktree", "new worktree", "create a worktree", "switch to a branch", "start work on a new feature/branch", "new bare repo workspace", or asks to work in a new/existing worktree. DO NOT run raw `git worktree` commands — this skill handles the bare repo pattern and hook lifecycle. If the user's memory mentions "worktrees/" paths, this skill is REQUIRED. Covers: creating worktrees, switching branches, cleanup, and the copy-ignored workflow for .env propagation.
+---
+
+# Bare Repo Workspaces
+
+Keep all your worktrees inside one project folder — clean, organized, self-contained.
+
+> **Tooling**: [Worktrunk](https://worktrunk.dev) (`wt`) is the preferred tool for all worktree operations. It wraps `git worktree` with ergonomic commands, lifecycle hooks, and `copy-ignored` for cache/env sharing. Install: `brew install worktrunk && wt config shell install`.
+
+## Scripts
+
+This skill includes helper scripts in `scripts/`:
+
+| Script | Purpose |
+|--------|---------|
+| `setup-workspace.sh` | One-time setup: create bare repo workspace from URL or upgrade existing checkout. |
+| `doctor.sh` | Diagnose and fix bare repo workspace issues (e.g., Antigravity compatibility). |
+
+### doctor.sh — Diagnose and fix workspace issues
+
+```bash
+# Diagnose only
+bash ~/.letta/skills/bare-repo-workspaces/scripts/doctor.sh ~/Code/alliance/ragtime
+
+# Diagnose and fix
+bash ~/.letta/skills/bare-repo-workspaces/scripts/doctor.sh --fix ~/Code/alliance/skills
+```
+
+**Checks for:**
+- Antigravity compatibility (repositoryformatversion, relative paths config)
+- Relative vs absolute paths in `.git` files and `gitdir` files
+- Missing `.git` pointer file at workspace root
+
+**For daily workflow, use `wt` commands:**
+- `wt switch --create feat/my-feature` — create a new worktree
+- `wt switch main` — switch to existing worktree
+- `wt list` — show all worktrees
+- `wt remove feat/my-feature` — clean up after merge
+
+**Use `setup-workspace.sh` only for initial workspace creation** — it handles edge cases like detaching HEAD before worktree creation.
+
+## Why
+
+Standard `git worktree add ../feature` scatters directories alongside real repos. After a few months, you can't tell worktrees from clones at a glance.
+
+The bare repo pattern fixes this:
+
+```
+my-project/
+├── .bare/           # all git data (bare clone)
+├── .git             # pointer FILE (not folder) → .bare
+├── main/             # primary worktree — source of truth for shared files
+│   ├── .env         # REAL file (copied to new worktrees via copy-ignored)
+│   └── apps/
+│       └── server/.env  # REAL file
+├── feat-my-feature/
+└── fix-some-bug/
+```
+
+**Key principles:**
+- `main/` is the **primary worktree** and source of truth for all shared files
+- **All** worktrees — primary and feature branches alike — live directly in the workspace root, named using `{{ branch | sanitize }}` (slashes become dashes)
+- Shared files (`.env`, build caches) are propagated to new worktrees automatically via `wt step copy-ignored` — no symlinks needed
+- Tool-specific config folders that should be scoped to the whole project (not per-branch) belong at the **workspace root as real directories** — not inside worktrees, not as symlinks
+- **Version manager config files** (`.prototools`, `.tool-versions`) must be **symlinked** at the workspace root to the primary worktree's file, so tools like proto/asdf resolve correct versions when the agent's shell starts in the workspace root (not a worktree). Create: `ln -s main/.prototools .prototools`
+
+---
+
+## Worktrunk Hooks (`.config/wt.toml`)
+
+Commit this file to the repo — it's shared with the team and automates worktree setup:
+
+```toml
+# .config/wt.toml
+
+[pre-start]
+# Blocking — runs before post-start hooks or --execute
+# ⚠️  Only fires when creating a NEW worktree (wt switch --create)
+deps = "pnpm install"   # Node.js
+# deps = "uv sync"      # Python
+
+[post-start]
+# Background — runs after worktree is ready
+# ⚠️  Only fires when creating a NEW worktree (wt switch --create)
+copy = "wt step copy-ignored"   # copies .env, build caches from main worktree
+
+[post-switch]
+# Background — runs after EVERY wt switch, including switching to existing worktrees
+# Add this so deps stay current when you return to an old worktree
+deps = "pnpm install"
+```
+
+> **Hook lifecycle summary**: `pre-start` → new worktrees only (blocking). `post-start` → new worktrees only (background). `post-switch` → every switch, new or existing (background). If you only have `pre-start` / `post-start`, running `wt switch main` on an existing worktree will **not** install deps.
+
+### `.worktreeinclude` — scope what `copy-ignored` copies
+
+By default `copy-ignored` copies ALL gitignored files. Scope it with `.worktreeinclude`:
+
+```
+# .worktreeinclude
+# Must be gitignored AND listed here to be copied.
+
+# Environment files
+.env
+.envrc
+
+# Build caches
+# .next/ intentionally excluded — Next.js incremental cache is branch-specific;
+# copying from main can produce stale/incorrect builds on feature branches.
+# .turbo/ is safe — content-addressed, stale entries are ignored.
+.turbo/
+```
+
+> **`.next/` vs `.turbo/`**: Don't copy `.next/` — its incremental cache is tied to specific file content and can produce incorrect builds if copied across branches. Do copy `.turbo/` — it's content-addressed; stale entries are simply ignored, valid hits speed up first builds.
+
+### Project hooks require one-time approval
+
+The first `wt switch --create` after the config lands will prompt:
+```
+▲ repo needs approval to execute 2 commands: [y/N]
+```
+Press `y` — saved to `~/.config/worktrunk/config.toml`, never asked again (unless the command changes).
+
+---
+
+## Worktrunk User Config
+
+`worktree-path` at the **top level** of `~/.config/worktrunk/config.toml` is a global default that applies to every repo. Per-project entries under `[projects."..."]` override it when needed.
+
+```toml
+# ~/.config/worktrunk/config.toml
+
+# Global default — all repos use <branch-sanitized>/ at workspace root
+worktree-path = "{{ branch | sanitize }}"
+```
+
+If one repo needs a different layout, override just that one:
+
+```toml
+# Override for a specific project only
+[projects."github.com/org/legacy-repo"]
+worktree-path = "../.worktrees/{{ branch | sanitize }}"
+```
+
+### Auto-sync primary worktree before switch
+
+`wt switch --create` branches from the local default branch. If the primary worktree is behind `origin`, new worktrees start stale — causing merge conflicts later. Add a `pre-switch` hook to auto-pull:
+
+```toml
+# ~/.config/worktrunk/config.toml
+# repo_path is the workspace root; main worktree is a subdirectory
+[pre-switch]
+sync = "test -d \"{{ repo_path }}/main\" && git -C \"{{ repo_path }}/main\" pull --ff-only 2>/dev/null || true"
+```
+
+This runs before every `wt switch`, fast-forwarding the primary worktree to match origin. `test -d` ensures the hook skips gracefully when no worktree exists yet. `--ff-only` ensures it never creates merge commits, and `|| true` means it won't block if there's no network.
+
+For repos where the primary worktree is a sibling (not inside the repo):
+```toml
+[projects."github.com/org/other-repo"]
+worktree-path = "{{ branch | sanitize }}"
+```
+
+---
+
+## Daily Workflow
+
+### Create a feature worktree (interactive terminal)
+
+> **⚠️ CRITICAL: Run `wt switch --create` from INSIDE the primary worktree (e.g., `main/`), NOT from the workspace root.**
+>
+> If run from the workspace root, `git rev-parse --show-toplevel` fails (not a work tree), `wt` falls back to `git-common-dir` (`.bare/`), and the worktree may be created inside `.bare/` instead of workspace root. Those malformed worktrees cause pre-commit to fail (`git toplevel unexpectedly empty`).
+
+```bash
+# 1. cd into the primary worktree FIRST
+cd main
+
+# 2. Create worktree + branch (shell integration required for cd)
+wt switch --create feat/my-feature
+
+# With a specific base branch:
+wt switch --create feat/my-feature --base main
+
+# Create and immediately launch Letta Code:
+wt switch --create feat/my-feature -x "letta code ."
+```
+
+Worktrunk runs `pre-start` (blocking: deps install) then `post-start` (background: copy-ignored) automatically. If `[post-switch]` is configured, it also runs in the background after every switch.
+
+### Create a feature worktree (non-interactive: Letta Code, CI, scripts)
+
+**⚠️ Run from INSIDE the primary worktree** — same as interactive workflow. If run from workspace root, worktrees may be created under `.bare/` instead of workspace root.
+
+**⚠️ `post-start` hooks do NOT fire in non-interactive shells** — shell integration is not active, so `wt step copy-ignored` never runs. `.env` and other gitignored files won't be copied unless you run the hook commands manually.
+
+```bash
+# 1. cd into the primary worktree FIRST
+cd main
+
+# 2. Create the worktree (pre-start hooks like `uv sync` still run)
+wt switch --create feat/my-feature
+
+# 3. cd into the new worktree
+cd feat-my-feature
+
+# 4. Manually run post-start hook commands that were skipped
+wt step copy-ignored
+```
+
+**Always run `wt step copy-ignored` after `wt switch --create`** in non-interactive contexts. Without it, `.env` files, `.letta/` directories, and any other files listed in `.worktreeinclude` will be missing.
+
+### List worktrees
+
+```bash
+wt list              # status: staged, unstaged, ahead/behind remote
+git worktree list    # plain git fallback (paths only)
+```
+
+### Clean up after PR merge
+
+> **⚠️ Don't run `wt remove` from inside the worktree you're removing.** Your shell's CWD becomes invalid and subsequent commands fail. Switch to the primary worktree (or workspace root) first.
+
+```bash
+# 1. Switch OUT of the worktree first
+cd ~/projects/my-project       # workspace root
+# or: wt switch ^              # switch to primary worktree
+
+# 2. Then remove
+wt remove feat/my-feature      # removes worktree + deletes branch if merged
+wt step prune                  # removes ALL worktrees whose branches are merged
+```
+
+### Update primary worktree
+
+```bash
+cd ~/projects/my-project/main
+git pull
+```
+
+---
+
+## Option A: Fresh Setup (from GitHub URL)
+
+### Quick setup with setup-workspace.sh (recommended)
+
+Use the setup script to automate the entire setup:
+
+```bash
+# Fresh setup from remote URL
+bash ~/.letta/skills/bare-repo-workspaces/scripts/setup-workspace.sh <repo-url> <target-dir> [--copy-from <old-clone>] [--main-branch <branch>]
+
+# Example:
+bash ~/.letta/skills/bare-repo-workspaces/scripts/setup-workspace.sh git@github.com:etalab-ia/skills.git ~/Code/alliance/skills
+
+# With optional env file copy from existing clone:
+bash ~/.letta/skills/bare-repo-workspaces/scripts/setup-workspace.sh git@github.com:org/repo.git ~/projects/repo --copy-from ~/old-clone
+```
+
+The script handles:
+- Bare clone with `--single-branch`
+- `.git` pointer file creation
+- Git config (fetch, relative paths, signing)
+- Creating the primary worktree (detaches HEAD first to avoid conflicts)
+- Copying `.env` files from an existing clone (if `--copy-from` provided)
+- Creating placeholder directories (`feat/`, `fix/`, `hotfix/`, `docs/`)
+
+---
+
+### Manual setup (if setup-workspace.sh unavailable)
+
+### Determine the workspace location
+
+**When the user starts from a parent directory** (e.g., `~/Code/alliance`) and provides a GitHub URL (e.g., `git@github.com:etalab-ia/skills.git`):
+
+1. **Derive the workspace name from the repo name** — extract the final segment before `.git`:
+   - `git@github.com:etalab-ia/skills.git` → workspace name is `skills`
+   - `https://github.com/org/my-project.git` → workspace name is `my-project`
+
+2. **Create the workspace as a SUBDIRECTORY of the current working directory**:
+   - Current directory: `~/Code/alliance`
+   - GitHub URL: `git@github.com:etalab-ia/skills.git`
+   - Workspace path: `~/Code/alliance/skills`
+
+3. **Do NOT create the bare repo directly in the current directory** — this would pollute the parent with `.bare/`, `.git`, and worktree directories mixed alongside other projects.
+
+```bash
+# Example: User is in ~/Code/alliance, URL is git@github.com:etalab-ia/skills.git
+
+# 1. Create the workspace directory as a subdirectory of current location
+mkdir skills && cd skills
+
+# Now in ~/Code/alliance/skills — proceed with bare clone
+```
+
+**When the user explicitly specifies a workspace path** (e.g., "create workspace at ~/projects/my-project"):
+
+```bash
+mkdir -p ~/projects/my-project && cd ~/projects/my-project
+```
+
+---
+
+### Complete setup sequence
+
+Once you've created and entered the workspace directory (whether derived from URL or explicitly specified), run the following:
+
+```bash
+# 2. Bare clone (--single-branch avoids creating 60+ stale local branches)
+git clone --bare --single-branch git@github.com:org/repo.git .bare
+
+# 3. Create the .git POINTER FILE (not a folder — this is the magic)
+echo "gitdir: ./.bare" > .git
+
+# 4. Configure fetch for all remote branches
+git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+
+# 5. Enable commit signing
+git config commit.gpgsign true
+
+# 6. Fetch all remote branches
+git fetch --all
+
+# 7. Create the primary worktree at workspace root
+git worktree add main main
+git -C main branch --set-upstream-to=origin/main main
+
+# 9. Copy secrets into main/ (source of truth)
+cp /path/to/old/.env main/.env
+cp /path/to/old/apps/server/.env main/apps/server/.env
+# ... etc
+
+# 10. Install dependencies
+cd main && pnpm install   # Node
+# cd main && uv sync      # Python
+
+# 11. Add worktrunk config
+mkdir -p .config
+cat > .config/wt.toml << 'EOF'
+[pre-start]
+deps = "pnpm install"
+
+[post-start]
+copy = "wt step copy-ignored"
+EOF
+
+# 12. Add .worktreeinclude to scope what copy-ignored copies
+cat > main/.worktreeinclude << 'EOF'
+.env
+.envrc
+.turbo/
+# Note: .next/ is intentionally excluded (branch-specific cache, risky to copy)
+EOF
+
+# 13. Set worktree path in user config
+wt config show   # verify project ID
+# Add to ~/.config/worktrunk/config.toml:
+# [projects."github.com/org/repo"]
+# worktree-path = "{{ branch | sanitize }}"
+```
+
+---
+
+## Option B: Upgrade Existing Workspace / Checkout (`--upgrade`)
+
+Use the helper script to upgrade in place.
+
+### 1) Standard checkout (`.git` directory) → bare workspace format
+
+```bash
+# IMPORTANT: run from OUTSIDE the workspace
+bash ~/.letta/skills/bare-repo-workspaces/scripts/setup-workspace.sh --upgrade ~/projects/my-project --main-branch main
+```
+
+### 2) Existing bare workspace using `worktrees/` layout → root-level layout
+
+```bash
+# IMPORTANT: run from OUTSIDE the workspace
+bash ~/.letta/skills/bare-repo-workspaces/scripts/setup-workspace.sh --upgrade ~/projects/my-project --main-branch main
+```
+
+The script auto-detects the workspace type and applies the right migration path.
+
+### 3) Update Worktrunk user config
+
+```toml
+# ~/.config/worktrunk/config.toml
+worktree-path = "{{ branch | sanitize }}"
+```
+
+### 4) Verify
+
+```bash
+git -C ~/projects/my-project worktree list
+```
+
+---
+
+## Per-Ecosystem: Dependencies
+
+### Node.js (pnpm)
+
+```toml
+[pre-start]
+deps = "pnpm install"
+
+[post-start]
+copy = "wt step copy-ignored"  # copies .env, .turbo/ cache from primary worktree
+```
+
+**Gotchas:**
+- Lock files (`pnpm-lock.yaml`) are git-tracked — already in every worktree, do NOT include in `.worktreeinclude`
+- `.npmrc` with auth tokens → put in `main/`, add to `.worktreeinclude`
+
+### Python (uv)
+
+```toml
+[pre-start]
+deps = "uv sync"
+# Don't copy .venv/ — virtual envs have hardcoded absolute paths
+```
+
+**Gotchas:**
+- **Wrong venv**: If `VIRTUAL_ENV` points to another worktree's `.venv`, tests run against wrong code. Use `uv run python -m pytest` — always uses local `.venv`.
+- **Stale shebangs**: `.venv/bin/*` scripts have path hardcoded. Moving the repo breaks them. Fix: `rm -rf .venv && uv sync`.
+- **Pre-commit hooks + unstaged files**: If a hook auto-modifies a file with unstaged changes in the same file, commit rolls back. Fix: `git stash push -- <file>` before committing.
+
+### Mixed Python + Node
+
+```toml
+[pre-start]
+deps = "uv sync && pnpm install"
+```
+
+---
+
+## Monorepo: Nested Env Files
+
+For monorepos with app-level secrets (`apps/server/.env`, `apps/client/.env`), list each in `.worktreeinclude`:
+
+```
+# .worktreeinclude
+.env
+apps/server/.env
+apps/client/.env
+apps/mobile/.env
+apps/storybook/.env
+.turbo/
+# .next/ intentionally excluded — branch-specific, risky to copy
+```
+
+`wt step copy-ignored` handles the nested structure automatically — it copies each listed file from the primary worktree into the same path in the new worktree.
+
+---
+
+## Build Tool Gotchas
+
+### Moon v1 (moonrepo)
+
+Moon v1 doesn't support bare repo worktrees ([moonrepo/moon#2162](https://github.com/moonrepo/moon/issues/2162)):
+
+1. **Git errors in moon tasks** — Workaround: `export GIT_WORK_TREE := justfile_directory()` in `justfile`
+2. **Orphaned processes** — Moon exits early but dev servers keep running, holding ports. Fix: bypass moon for dev servers, use `just run <app>` directly.
+
+Both issues are fixed in moon v2.
+
+### Cargo (Rust)
+
+- `target/` is per-worktree — add to `.worktreeinclude` for fast reflink copies
+- `.cargo/credentials.toml` → put in `main/`, add to `.worktreeinclude`
+
+---
+
+## Gotchas Summary
+
+| Issue | Root Cause | Fix |
+|-------|-----------|-----|
+| **`wt switch` can't cd** | Shell integration not installed | `wt config shell install` |
+| **`.env` missing after `wt switch --create` in Letta Code / scripts** | `post-start` hooks require shell integration (interactive shell); non-interactive shells skip them entirely | **Always** run `cd <branch-sanitized> && wt step copy-ignored` manually after `wt switch --create` |
+| **Hooks need approval** | Worktrunk security: project commands require one-time consent | Run `wt switch --create` and press `y` on first prompt |
+| **66 stale local branches after bare clone** | `git clone --bare` without `--single-branch` | Always use `--single-branch` on bare clone |
+| **`git push` fails: "no upstream configured"** | Bare clone worktrees don't auto-set tracking | `git branch --set-upstream-to=origin/<branch>` |
+| **Wrong venv / tests run old code** | `VIRTUAL_ENV` pointing to different worktree's `.venv` | Use `uv run python -m pytest` |
+| **Stale venv shebangs after repo move** | `.venv/bin/*` scripts have old path hardcoded | `rm -rf .venv && uv sync` |
+| **Pre-commit hook conflict** | Hook modifies file; unstaged changes in same file cause rollback | `git stash push -- <file>` before committing |
+| **Moon port conflict / orphaned server** | Moon v1 exits early in bare repos, child process stays on port | Use `just run <app>` to bypass moon for dev servers |
+| **IDE shows wrong branch** | Opening workspace root instead of a specific worktree | Open `main/` or `feat-my-feature/` directly |
+| **Shell dies after `mv` during in-place migration** | `mv` invalidates CWD — all commands fail | `cd` out of the repo before the rename |
+| **`git worktree add` fails: "already used"** | Bare clone HEAD points to main branch, making it "used" | Detach HEAD first: `git symbolic-ref HEAD refs/heads/__bare_placeholder__` (setup-workspace.sh does this automatically) |
+| **`wt switch --create` creates worktree in `.bare/` instead of workspace root** | Running `wt` from workspace root instead of inside primary worktree | `cd main` BEFORE `wt switch --create` |
+| **Need to upgrade old `worktrees/` layout to root-level** | Earlier setup used `worktrees/<branch>` | Run `setup-workspace.sh --upgrade <workspace-dir>` from outside the workspace |
+| **New worktree starts stale / conflicts** | Primary worktree behind `origin` when `wt switch --create` runs | Add `pre-switch` hook: `test -d \"{{ repo_path }}/main\" && git -C \"{{ repo_path }}/main\" pull --ff-only` |
+| **Agent executes manual steps instead of using setup script** | Skill documentation showed manual steps before scripts section | Always check `scripts/` directory first — use `setup-workspace.sh` for fresh setup |
+| **`pnpm install` (or `uv sync`) doesn't run when switching back to existing worktree** | `pre-start` / `post-start` only fire for NEW worktrees; `wt switch main` on an existing worktree skips them entirely | Add `[post-switch] deps = \"pnpm install\"` to `.config/wt.toml` |
+| **Antigravity / IDE fails to open workspace** | `repositoryformatversion = 1` with `worktree.useRelativePaths = true` or `extensions.relativeWorktrees = true` breaks Git parsers | Run `doctor.sh --fix <workspace>` to fix |
+
+---
+
+## Rules
+
+- **Use `wt` for all worktree operations** — `wt switch --create`, `wt list`, `wt remove`, `wt step prune`
+- **Run `wt switch --create` from INSIDE the primary worktree** (`main/`) — NEVER from workspace root. Running from root can create malformed worktrees in `.bare/`
+- `main/` is the **source of truth** for all shared files — pull frequently, **never commit work directly to it**
+- **`wt step copy-ignored` + `.worktreeinclude`** handles gitignored files (`.env`, build caches) — no manual symlink setup needed
+- **All** worktrees — including the primary — live at workspace root — configured via `worktree-path` in worktrunk user config
+- Each worktree has its own `node_modules` / `.venv` — automate via `.config/wt.toml` hooks
+- Keep 2–4 active worktrees max; `wt step prune` to remove stale ones
+- Open a **specific worktree** in your IDE, not the workspace root
+- Tool-specific config folders scoped to the whole project (not per-branch) belong at the **workspace root as real directories**, not inside worktrees
+- **Version manager config files** (`.prototools`, `.tool-versions`) → **symlink** at workspace root to primary worktree's file (e.g., `ln -s main/.prototools .prototools`)

--- a/development/git/bare-repo-workspaces/SKILL.md
+++ b/development/git/bare-repo-workspaces/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: bare-repo-workspaces
-description: Git worktree operations using Worktrunk (wt). LOAD THIS SKILL whenever the user mentions "worktree", "new worktree", "create a worktree", "switch to a branch", "start work on a new feature/branch", "new bare repo workspace", or asks to work in a new/existing worktree. DO NOT run raw `git worktree` commands — this skill handles the bare repo pattern and hook lifecycle. If the user's memory mentions "worktrees/" paths, this skill is REQUIRED. Covers: creating worktrees, switching branches, cleanup, and the copy-ignored workflow for .env propagation.
+description: Git worktree operations using Worktrunk (wt) for EXISTING bare-repo workspaces (`.bare/` + `.git` pointer file + primary worktree as a subdirectory). LOAD THIS SKILL only when working inside a repo that is already set up in the bare-repo layout (legacy workspaces, non-interactive remote workers). For new clones and standard checkouts, use Letta Code's built-in EnterWorktree tool (worktrees under `.letta/worktrees/`) instead — do NOT apply or convert to the bare layout. Covers: creating worktrees, switching branches, cleanup, and the copy-ignored workflow for .env propagation.
 ---
 
 # Bare Repo Workspaces
+
+> **⚠️ Scope: existing bare-repo workspaces only.** Letta Code's built-in worktree management (the `EnterWorktree` tool) expects a standard (non-bare) checkout and creates worktrees under `.letta/worktrees/`. That is the default layout for all new repos. Use **this** skill only when the repo is *already* in the bare-repo layout (legacy workspaces, non-interactive remote workers). Never apply it to a fresh clone, and never convert a standard checkout unless the user explicitly asks.
 
 Keep all your worktrees inside one project folder — clean, organized, self-contained.
 
@@ -127,41 +129,38 @@ Press `y` — saved to `~/.config/worktrunk/config.toml`, never asked again (unl
 
 ## Worktrunk User Config
 
-`worktree-path` at the **top level** of `~/.config/worktrunk/config.toml` is a global default that applies to every repo. Per-project entries under `[projects."..."]` override it when needed.
+**Do NOT set a bare-oriented `worktree-path` as the global default.** A global default applies to every repo on the machine, including standard checkouts, where the Letta Code convention is worktrees under `.letta/worktrees/` inside the repo. Configure the bare layout **per project** instead:
 
 ```toml
 # ~/.config/worktrunk/config.toml
+# Global default stays aligned with the built-in layout (standard checkouts):
+worktree-path = ".letta/worktrees/{{ branch | sanitize }}"
 
-# Global default — all repos use <branch-sanitized>/ at workspace root
-worktree-path = "{{ branch | sanitize }}"
-```
-
-If one repo needs a different layout, override just that one:
-
-```toml
-# Override for a specific project only
-[projects."github.com/org/legacy-repo"]
-worktree-path = "../.worktrees/{{ branch | sanitize }}"
+# Per-project override for THIS bare workspace only.
+# repo_path resolves to .bare for bare repositories, so ../ lands at the
+# workspace root beside main/.
+[projects."github.com/org/this-bare-repo"]
+worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ```
 
 ### Auto-sync primary worktree before switch
 
-`wt switch --create` branches from the local default branch. If the primary worktree is behind `origin`, new worktrees start stale — causing merge conflicts later. Add a `pre-switch` hook to auto-pull:
+`wt switch --create` branches from the local default branch. If the primary worktree is behind `origin`, new worktrees start stale — causing merge conflicts later. Add a `pre-switch` hook to auto-pull, scoped to the bare project:
 
 ```toml
 # ~/.config/worktrunk/config.toml
-# repo_path is the workspace root; main worktree is a subdirectory
-[pre-switch]
-sync = "test -d \"{{ repo_path }}/main\" && git -C \"{{ repo_path }}/main\" pull --ff-only 2>/dev/null || true"
+# repo_path resolves to .bare for bare repositories; main worktree is ../main
+[projects."github.com/org/this-bare-repo".pre-switch]
+sync = "test -d \"{{ repo_path }}/../main\" && git -C \"{{ repo_path }}/../main\" pull --ff-only 2>/dev/null || true"
 ```
 
-This runs before every `wt switch`, fast-forwarding the primary worktree to match origin. `test -d` ensures the hook skips gracefully when no worktree exists yet. `--ff-only` ensures it never creates merge commits, and `|| true` means it won't block if there's no network.
+This runs before every `wt switch` in that project, fast-forwarding the primary worktree to match origin. `test -d` ensures the hook skips gracefully when no worktree exists yet. `--ff-only` ensures it never creates merge commits, and `|| true` means it won't block if there's no network.
 
-For repos where the primary worktree is a sibling (not inside the repo):
-```toml
-[projects."github.com/org/other-repo"]
-worktree-path = "{{ branch | sanitize }}"
-```
+## Interaction with Letta Code's built-in worktree management
+
+- The built-in `EnterWorktree` tool manages **standard checkouts only**: it creates worktrees under `.letta/worktrees/`, wires git hooks, copies `.worktreeinclude` entries, and tracks cross-agent locks. It does not manage bare-repo workspaces — do not call it inside one, and do not expect `ExitWorktree` cleanup to apply.
+- Letta Code's Bash tool statically rejects literal `git worktree add` commands whose target path is not under `.letta/worktrees/` ([letta-ai/letta-code#1829](https://github.com/letta-ai/letta-code/issues/1829)). Inside an existing bare workspace, use `wt switch --create` for worktree operations instead of raw `git worktree add`.
+- If the initial bare-workspace bootstrap is blocked by that guard, **stop and ask the user**. Do not work around the guard with variable indirection, script wrappers, or other evasion — the guard exists to keep agents on the built-in layout by default.
 
 ---
 
@@ -242,6 +241,8 @@ git pull
 ---
 
 ## Option A: Fresh Setup (from GitHub URL)
+
+> **⚠️ Only when explicitly requested.** The default for a new repo is a standard clone (`git clone <url>`) with worktrees under `.letta/worktrees/` via the built-in `EnterWorktree` tool. Run this bare-workspace setup only when the user has explicitly asked for the bare-repo layout (e.g., provisioning a non-interactive remote worker where `EnterWorktree` is unavailable).
 
 ### Quick setup with setup-workspace.sh (recommended)
 
@@ -357,7 +358,7 @@ EOF
 wt config show   # verify project ID
 # Add to ~/.config/worktrunk/config.toml:
 # [projects."github.com/org/repo"]
-# worktree-path = "{{ branch | sanitize }}"
+# worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ```
 
 ---
@@ -367,6 +368,8 @@ wt config show   # verify project ID
 Use the helper script to upgrade in place.
 
 ### 1) Standard checkout (`.git` directory) → bare workspace format
+
+> **⚠️ Only when explicitly requested.** Converting a standard checkout abandons the built-in `EnterWorktree` workflow (`.letta/worktrees/`) for this repo. Confirm with the user before running.
 
 ```bash
 # IMPORTANT: run from OUTSIDE the workspace
@@ -384,9 +387,12 @@ The script auto-detects the workspace type and applies the right migration path.
 
 ### 3) Update Worktrunk user config
 
+Per-project override only (see "Worktrunk User Config" above — never a global bare-oriented default):
+
 ```toml
 # ~/.config/worktrunk/config.toml
-worktree-path = "{{ branch | sanitize }}"
+[projects."github.com/org/my-project"]
+worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ```
 
 ### 4) Verify
@@ -490,7 +496,7 @@ Both issues are fixed in moon v2.
 | **`git worktree add` fails: "already used"** | Bare clone HEAD points to main branch, making it "used" | Detach HEAD first: `git symbolic-ref HEAD refs/heads/__bare_placeholder__` (setup-workspace.sh does this automatically) |
 | **`wt switch --create` creates worktree in `.bare/` instead of workspace root** | Running `wt` from workspace root instead of inside primary worktree | `cd main` BEFORE `wt switch --create` |
 | **Need to upgrade old `worktrees/` layout to root-level** | Earlier setup used `worktrees/<branch>` | Run `setup-workspace.sh --upgrade <workspace-dir>` from outside the workspace |
-| **New worktree starts stale / conflicts** | Primary worktree behind `origin` when `wt switch --create` runs | Add `pre-switch` hook: `test -d \"{{ repo_path }}/main\" && git -C \"{{ repo_path }}/main\" pull --ff-only` |
+| **New worktree starts stale / conflicts** | Primary worktree behind `origin` when `wt switch --create` runs | Add per-project `pre-switch` hook: `test -d \"{{ repo_path }}/../main\" && git -C \"{{ repo_path }}/../main\" pull --ff-only` |
 | **Agent executes manual steps instead of using setup script** | Skill documentation showed manual steps before scripts section | Always check `scripts/` directory first — use `setup-workspace.sh` for fresh setup |
 | **`pnpm install` (or `uv sync`) doesn't run when switching back to existing worktree** | `pre-start` / `post-start` only fire for NEW worktrees; `wt switch main` on an existing worktree skips them entirely | Add `[post-switch] deps = \"pnpm install\"` to `.config/wt.toml` |
 | **Antigravity / IDE fails to open workspace** | `repositoryformatversion = 1` with `worktree.useRelativePaths = true` or `extensions.relativeWorktrees = true` breaks Git parsers | Run `doctor.sh --fix <workspace>` to fix |
@@ -499,11 +505,12 @@ Both issues are fixed in moon v2.
 
 ## Rules
 
+- **Existing bare workspaces only** — never create the bare layout for a new repo clone unless the user explicitly asks; new repos are standard checkouts with worktrees under `.letta/worktrees/` via the built-in `EnterWorktree` tool
 - **Use `wt` for all worktree operations** — `wt switch --create`, `wt list`, `wt remove`, `wt step prune`
 - **Run `wt switch --create` from INSIDE the primary worktree** (`main/`) — NEVER from workspace root. Running from root can create malformed worktrees in `.bare/`
 - `main/` is the **source of truth** for all shared files — pull frequently, **never commit work directly to it**
 - **`wt step copy-ignored` + `.worktreeinclude`** handles gitignored files (`.env`, build caches) — no manual symlink setup needed
-- **All** worktrees — including the primary — live at workspace root — configured via `worktree-path` in worktrunk user config
+- **All** worktrees — including the primary — live at workspace root — configured via a **per-project** `worktree-path` override in worktrunk user config, never a global bare-oriented default
 - Each worktree has its own `node_modules` / `.venv` — automate via `.config/wt.toml` hooks
 - Keep 2–4 active worktrees max; `wt step prune` to remove stale ones
 - Open a **specific worktree** in your IDE, not the workspace root

--- a/development/git/bare-repo-workspaces/scripts/doctor.sh
+++ b/development/git/bare-repo-workspaces/scripts/doctor.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# Diagnose and fix issues with bare repo worktree workspaces.
+#
+# Usage:
+#   doctor.sh <workspace-dir>           # diagnose only
+#   doctor.sh --fix <workspace-dir>     # diagnose and fix issues
+#
+# Checks for:
+#   - Antigravity compatibility issues (repositoryformatversion, relative paths config)
+#   - Relative vs absolute paths in .git files and gitdir files
+#   - Missing .git pointer file at workspace root
+#   - Orphaned worktree entries
+#
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+usage() {
+  cat <<'EOF'
+Usage:
+  doctor.sh <workspace-dir>           # diagnose only
+  doctor.sh --fix <workspace-dir>     # diagnose and fix issues
+
+Examples:
+  doctor.sh ~/Code/alliance/ragtime
+  doctor.sh --fix ~/Code/alliance/skills
+EOF
+}
+
+# ── Diagnostic Functions ─────────────────────────────────────────────────────
+
+check_repositoryformatversion() {
+  local workspace="$1"
+  local config="$workspace/.bare/config"
+  local version
+
+  version=$(git -C "$workspace" config --get core.repositoryformatversion 2>/dev/null || echo "0")
+
+  if [[ "$version" == "1" ]]; then
+    echo -e "${YELLOW}⚠${NC} repositoryformatversion = 1 (should be 0 for Antigravity compatibility)"
+    return 1
+  else
+    echo -e "${GREEN}✓${NC} repositoryformatversion = 0"
+    return 0
+  fi
+}
+
+check_relative_paths_config() {
+  local workspace="$1"
+  local issues=0
+
+  if git -C "$workspace" config --get worktree.useRelativePaths 2>/dev/null | grep -q "true"; then
+    echo -e "${YELLOW}⚠${NC} worktree.useRelativePaths = true (causes Antigravity issues)"
+    issues=$((issues + 1))
+  else
+    echo -e "${GREEN}✓${NC} worktree.useRelativePaths is not set or false"
+  fi
+
+  if git -C "$workspace" config --get extensions.relativeWorktrees 2>/dev/null | grep -q "true"; then
+    echo -e "${YELLOW}⚠${NC} extensions.relativeWorktrees = true (causes Antigravity issues)"
+    issues=$((issues + 1))
+  else
+    echo -e "${GREEN}✓${NC} extensions.relativeWorktrees is not set or false"
+  fi
+
+  if (( issues > 0 )); then
+    return 1
+  fi
+  return 0
+}
+
+check_worktree_git_files() {
+  local workspace="$1"
+  local issues=0
+
+  while IFS= read -r worktree_git; do
+    local worktree_name parent_dir gitdir_path
+
+    parent_dir=$(dirname "$worktree_git")
+    worktree_name=$(basename "$parent_dir")
+    gitdir_path=$(head -1 "$worktree_git" 2>/dev/null | sed 's/^gitdir: //' || true)
+
+    if [[ -z "$gitdir_path" ]]; then
+      echo -e "${RED}✗${NC} $worktree_name/.git has invalid format"
+      issues=$((issues + 1))
+      continue
+    fi
+
+    # Check if path is relative (doesn't start with /)
+    if [[ "$gitdir_path" != /* ]]; then
+      echo -e "${YELLOW}⚠${NC} $worktree_name/.git uses relative path: $gitdir_path"
+      issues=$((issues + 1))
+    fi
+  done < <(find "$workspace" -mindepth 2 -maxdepth 2 -name ".git" -type f 2>/dev/null | sort)
+
+  if (( issues == 0 )); then
+    echo -e "${GREEN}✓${NC} All worktree .git files use absolute paths"
+    return 0
+  fi
+  return 1
+}
+
+check_gitdir_files() {
+  local workspace="$1"
+  local issues=0
+
+  if [[ ! -d "$workspace/.bare/worktrees" ]]; then
+    echo -e "${CYAN}ℹ${NC} No worktrees directory found"
+    return 0
+  fi
+
+  while IFS= read -r gitdir_file; do
+    local worktree_name gitdir_path
+
+    worktree_name=$(basename "$(dirname "$gitdir_file")")
+    gitdir_path=$(head -1 "$gitdir_file" 2>/dev/null || true)
+
+    if [[ -z "$gitdir_path" ]]; then
+      echo -e "${RED}✗${NC} .bare/worktrees/$worktree_name/gitdir is empty"
+      issues=$((issues + 1))
+      continue
+    fi
+
+    # Check if path is relative (doesn't start with /)
+    if [[ "$gitdir_path" != /* ]]; then
+      echo -e "${YELLOW}⚠${NC} .bare/worktrees/$worktree_name/gitdir uses relative path: $gitdir_path"
+      issues=$((issues + 1))
+    fi
+  done < <(find "$workspace/.bare/worktrees" -mindepth 2 -maxdepth 2 -name "gitdir" -type f 2>/dev/null | sort)
+
+  if (( issues == 0 )); then
+    echo -e "${GREEN}✓${NC} All gitdir files use absolute paths"
+    return 0
+  fi
+  return 1
+}
+
+check_root_git_pointer() {
+  local workspace="$1"
+  local git_file="$workspace/.git"
+  local gitdir_path
+
+  if [[ ! -f "$git_file" ]]; then
+    echo -e "${RED}✗${NC} Missing .git pointer file at workspace root"
+    return 1
+  fi
+
+  gitdir_path=$(head -1 "$git_file" 2>/dev/null | sed 's/^gitdir: //' || true)
+
+  if [[ -z "$gitdir_path" ]]; then
+    echo -e "${RED}✗${NC} .git pointer file has invalid format"
+    return 1
+  fi
+
+  echo -e "${GREEN}✓${NC} .git pointer file exists: $gitdir_path"
+  return 0
+}
+
+# ── Fix Functions ────────────────────────────────────────────────────────────
+
+fix_repositoryformatversion() {
+  local workspace="$1"
+  local config="$workspace/.bare/config"
+
+  # Check if the file has the section with version = 1
+  if grep -q "repositoryformatversion = 1" "$config" 2>/dev/null; then
+    sed -i '' 's/repositoryformatversion = 1/repositoryformatversion = 0/' "$config"
+    echo -e "  ${GREEN}Fixed${NC}: repositoryformatversion set to 0"
+  fi
+}
+
+fix_relative_paths_config() {
+  local workspace="$1"
+  local config="$workspace/.bare/config"
+  local fixed=0
+
+  # Remove [worktree] section if it exists (version 0 repos shouldn't have it)
+  if grep -qE "^\[worktree\]" "$config" 2>/dev/null; then
+    # Remove the entire [worktree] section
+    sed -i '' '/^\[worktree\]/,/^[^[:space:]]/{
+      /^\[worktree\]/d
+      /useRelativePaths/d
+    }' "$config" 2>/dev/null || true
+    echo -e "  ${GREEN}Fixed${NC}: Removed [worktree] section"
+    fixed=$((fixed + 1))
+  fi
+
+  # Remove [extensions] section if it exists (version 0 repos shouldn't have it)
+  if grep -qE "^\[extensions\]" "$config" 2>/dev/null; then
+    # Remove the entire [extensions] section
+    sed -i '' '/^\[extensions\]/,/^[^[:space:]]/{
+      /^\[extensions\]/d
+      /relativeWorktrees/d
+      /relativeworktrees/d
+    }' "$config" 2>/dev/null || true
+    echo -e "  ${GREEN}Fixed${NC}: Removed [extensions] section"
+    fixed=$((fixed + 1))
+  fi
+
+  echo "  Fixed $fixed config section(s)"
+}
+
+fix_worktree_git_files() {
+  local workspace="$1"
+  local fixed=0
+
+  while IFS= read -r worktree_git; do
+    local parent_dir worktree_name gitdir_path new_path
+
+    parent_dir=$(dirname "$worktree_git")
+    worktree_name=$(basename "$parent_dir")
+    gitdir_path=$(head -1 "$worktree_git" 2>/dev/null | sed 's/^gitdir: //' || true)
+
+    if [[ -z "$gitdir_path" ]]; then
+      continue
+    fi
+
+    # If relative, convert to absolute
+    if [[ "$gitdir_path" != /* ]]; then
+      new_path="$workspace/.bare/worktrees/$worktree_name"
+      echo "gitdir: $new_path" > "$worktree_git"
+      echo -e "  ${GREEN}Fixed${NC}: $worktree_name/.git → absolute path"
+      fixed=$((fixed + 1))
+    fi
+  done < <(find "$workspace" -mindepth 2 -maxdepth 2 -name ".git" -type f 2>/dev/null | sort)
+
+  echo "  Fixed $fixed worktree .git file(s)"
+}
+
+fix_gitdir_files() {
+  local workspace="$1"
+  local fixed=0
+
+  if [[ ! -d "$workspace/.bare/worktrees" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r gitdir_file; do
+    local worktree_name gitdir_path new_path
+
+    worktree_name=$(basename "$(dirname "$gitdir_file")")
+    gitdir_path=$(head -1 "$gitdir_file" 2>/dev/null || true)
+
+    if [[ -z "$gitdir_path" ]]; then
+      continue
+    fi
+
+    # If relative, convert to absolute
+    if [[ "$gitdir_path" != /* ]]; then
+      # Find the worktree directory for this gitdir
+      # It should be workspace/<worktree_name>
+      new_path="$workspace/$worktree_name/.git"
+      echo "$new_path" > "$gitdir_file"
+      echo -e "  ${GREEN}Fixed${NC}: .bare/worktrees/$worktree_name/gitdir → absolute path"
+      fixed=$((fixed + 1))
+    fi
+  done < <(find "$workspace/.bare/worktrees" -name "gitdir" -type f 2>/dev/null | sort)
+
+  echo "  Fixed $fixed gitdir file(s)"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+FIX_MODE=false
+WORKSPACE=""
+
+if [[ "$1" == "--fix" ]]; then
+  FIX_MODE=true
+  WORKSPACE="${2:-}"
+  if [[ -z "$WORKSPACE" ]]; then
+    echo "Error: --fix requires a workspace path." >&2
+    usage
+    exit 1
+  fi
+  shift 2
+else
+  WORKSPACE="$1"
+  shift
+fi
+
+if [[ ! -d "$WORKSPACE" ]]; then
+  echo "Error: workspace '$WORKSPACE' does not exist." >&2
+  exit 1
+fi
+
+# Resolve to absolute path
+WORKSPACE_ABS=$(cd "$WORKSPACE" && pwd)
+
+# Verify it's a bare repo workspace
+if [[ ! -d "$WORKSPACE_ABS/.bare" ]]; then
+  echo -e "${RED}Error${NC}: '$WORKSPACE_ABS' does not appear to be a bare repo workspace (.bare/ not found)." >&2
+  exit 1
+fi
+
+echo ""
+echo -e "${CYAN}Bare Repo Worktree Doctor${NC}"
+echo "================================"
+echo "Workspace: $WORKSPACE_ABS"
+echo ""
+
+if [[ "$FIX_MODE" == true ]]; then
+  echo -e "${CYAN}Running diagnostics and fixes...${NC}"
+  echo ""
+else
+  echo -e "${CYAN}Running diagnostics...${NC}"
+  echo ""
+fi
+
+ISSUES=0
+
+# Run diagnostics
+check_root_git_pointer "$WORKSPACE_ABS" || ISSUES=$((ISSUES + 1))
+check_repositoryformatversion "$WORKSPACE_ABS" || ISSUES=$((ISSUES + 1))
+check_relative_paths_config "$WORKSPACE_ABS" || ISSUES=$((ISSUES + 1))
+check_worktree_git_files "$WORKSPACE_ABS" || ISSUES=$((ISSUES + 1))
+check_gitdir_files "$WORKSPACE_ABS" || ISSUES=$((ISSUES + 1))
+
+echo ""
+
+if [[ "$FIX_MODE" == true ]]; then
+  echo -e "${CYAN}Applying fixes...${NC}"
+  echo ""
+
+  # IMPORTANT: Fix paths BEFORE config changes
+  # Changing repositoryformatversion before fixing relative paths
+  # can cause Git to prune worktrees
+  fix_worktree_git_files "$WORKSPACE_ABS"
+  fix_gitdir_files "$WORKSPACE_ABS"
+  fix_repositoryformatversion "$WORKSPACE_ABS"
+  fix_relative_paths_config "$WORKSPACE_ABS"
+
+  echo ""
+
+  # Verify git still works
+  echo "Verifying git operations..."
+  if git -C "$WORKSPACE_ABS" worktree list > /dev/null 2>&1; then
+    echo -e "${GREEN}✓${NC} git worktree list: OK"
+  else
+    echo -e "${RED}✗${NC} git worktree list: FAILED"
+  fi
+else
+  if (( ISSUES > 0 )); then
+    echo -e "${YELLOW}Found $ISSUES issue(s).${NC} Run with --fix to resolve."
+  else
+    echo -e "${GREEN}All checks passed!${NC}"
+  fi
+fi
+
+echo ""

--- a/development/git/bare-repo-workspaces/scripts/setup-workspace.sh
+++ b/development/git/bare-repo-workspaces/scripts/setup-workspace.sh
@@ -1,0 +1,491 @@
+#!/usr/bin/env bash
+# Set up a bare repo worktree workspace.
+#
+# Modes:
+#   1) Fresh setup from remote URL
+#      setup-workspace.sh <repo-url> <target-dir> [--copy-from <old-clone>] [--main-branch <branch>]
+#
+#   2) Upgrade existing local checkout/workspace
+#      setup-workspace.sh --upgrade <workspace-dir> [--main-branch <branch>]
+#
+# `--upgrade` supports:
+#   - Standard checkout (.git directory) -> bare workspace format
+#   - Existing bare workspace using worktrees/ layout -> root-level layout
+#
+# Backward compatible aliases:
+#   --copy-envs-from, --move-env-from (same as --copy-from)
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  setup-workspace.sh <repo-url> <target-dir> [--copy-from <old-clone>] [--main-branch <branch>]
+  setup-workspace.sh --upgrade <workspace-dir> [--main-branch <branch>]
+
+Examples:
+  setup-workspace.sh git@github.com:org/repo.git ~/projects/repo --main-branch dev
+  setup-workspace.sh --upgrade ~/projects/repo --main-branch dev
+EOF
+}
+
+is_git_pointer_file() {
+  local workspace="$1"
+  [[ -f "$workspace/.git" ]] && grep -q "^gitdir: " "$workspace/.git" 2>/dev/null
+}
+
+require_outside_workspace() {
+  local workspace="$1"
+  case "$PWD" in
+    "$workspace"|"$workspace"/*)
+      echo "Error: run this command from outside '$workspace' to avoid invalid CWD during migration." >&2
+      exit 1
+      ;;
+  esac
+}
+
+detect_default_main_branch() {
+  local workspace="$1"
+
+  if [[ -d "$workspace/worktrees/dev" || -d "$workspace/dev" ]]; then
+    echo "dev"
+    return
+  fi
+
+  if [[ -d "$workspace/worktrees/main" || -d "$workspace/main" ]]; then
+    echo "main"
+    return
+  fi
+
+  local head_branch
+  head_branch="$(git -C "$workspace" symbolic-ref --short HEAD 2>/dev/null || true)"
+  if [[ -n "$head_branch" && "$head_branch" != "__bare_placeholder__" ]]; then
+    echo "$head_branch"
+    return
+  fi
+
+  local remote_head
+  remote_head="$(git -C "$workspace" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  remote_head="${remote_head#origin/}"
+  if [[ -n "$remote_head" ]]; then
+    echo "$remote_head"
+    return
+  fi
+
+  echo "main"
+}
+
+configure_bare_workspace() {
+  local workspace="$1"
+
+  git -C "$workspace" config core.bare false
+
+  if git -C "$workspace" remote get-url origin >/dev/null 2>&1; then
+    git -C "$workspace" config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+  fi
+
+  # Note: Do NOT set worktree.useRelativePaths = true
+  # It breaks compatibility with Antigravity and other Git parsers
+  git -C "$workspace" config commit.gpgsign true
+}
+
+set_branch_tracking_if_remote_exists() {
+  local workspace="$1"
+  local main_branch="$2"
+  local main_dir="$workspace/$main_branch"
+
+  if git -C "$workspace" show-ref --verify --quiet "refs/remotes/origin/$main_branch"; then
+    git -C "$main_dir" branch --set-upstream-to="origin/$main_branch" "$main_branch" >/dev/null 2>&1 || true
+  fi
+}
+
+move_workspace_contents_to_backup() {
+  local workspace="$1"
+  local backup_dir="$2"
+
+  shopt -s dotglob nullglob
+  local entry
+  for entry in "$workspace"/*; do
+    local base
+    base="$(basename "$entry")"
+    [[ "$base" == ".git" ]] && continue
+    mv "$entry" "$backup_dir/"
+  done
+  shopt -u dotglob nullglob
+}
+
+restore_backup_into_main() {
+  local backup_dir="$1"
+  local main_dir="$2"
+
+  shopt -s dotglob nullglob
+  local entry
+  for entry in "$backup_dir"/*; do
+    local base target
+    base="$(basename "$entry")"
+    target="$main_dir/$base"
+    if [[ -e "$target" || -L "$target" ]]; then
+      rm -rf "$target"
+    fi
+    mv "$entry" "$main_dir/"
+  done
+  shopt -u dotglob nullglob
+
+  rmdir "$backup_dir"
+}
+
+rewrite_root_symlinks_from_worktrees_prefix() {
+  local workspace="$1"
+  local rewritten=0
+
+  while IFS= read -r link_path; do
+    local target new_target
+    target="$(readlink "$link_path")"
+    new_target=""
+
+    case "$target" in
+      worktrees/*)
+        new_target="${target#worktrees/}"
+        ;;
+      ./worktrees/*)
+        new_target="./${target#./worktrees/}"
+        ;;
+      "$workspace"/worktrees/*)
+        new_target="$workspace/${target#$workspace/worktrees/}"
+        ;;
+    esac
+
+    if [[ -n "$new_target" && "$new_target" != "$target" ]]; then
+      ln -sfn "$new_target" "$link_path"
+      echo "  Rewrote symlink: $(basename "$link_path") -> $new_target"
+      rewritten=$((rewritten + 1))
+    fi
+  done < <(find "$workspace" -mindepth 1 -maxdepth 1 -type l | sort)
+
+  if (( rewritten > 0 )); then
+    echo "Updated $rewritten top-level symlink(s) that referenced worktrees/."
+  fi
+}
+
+upgrade_standard_checkout_in_place() {
+  local workspace="$1"
+  local main_branch="$2"
+
+  if [[ ! -d "$workspace/.git" ]]; then
+    echo "Error: '$workspace' does not look like a standard checkout (.git directory not found)." >&2
+    exit 1
+  fi
+
+  if [[ -d "$workspace/.bare" ]]; then
+    echo "Error: '$workspace' already has .bare/. Use '--upgrade' on that workspace layout instead." >&2
+    exit 1
+  fi
+
+  if ! git -C "$workspace" rev-parse --verify --quiet "$main_branch" >/dev/null; then
+    if ! git -C "$workspace" show-ref --verify --quiet "refs/remotes/origin/$main_branch"; then
+      echo "Error: main branch '$main_branch' was not found locally or on origin." >&2
+      exit 1
+    fi
+  fi
+
+  local backup_dir
+  backup_dir="$(mktemp -d "${TMPDIR:-/tmp}/bare-repo-upgrade.XXXXXX")"
+
+  echo "Temporarily moving current checkout files to: $backup_dir"
+  move_workspace_contents_to_backup "$workspace" "$backup_dir"
+
+  echo "Converting .git directory -> .bare..."
+  mv "$workspace/.git" "$workspace/.bare"
+  echo "gitdir: ./.bare" > "$workspace/.git"
+
+  configure_bare_workspace "$workspace"
+
+  if git -C "$workspace" remote get-url origin >/dev/null 2>&1; then
+    echo "Fetching remote branches..."
+    git -C "$workspace" fetch --all --quiet || echo "Warning: fetch failed; continuing with local refs."
+  fi
+
+  if ! git -C "$workspace" show-ref --verify --quiet "refs/heads/$main_branch"; then
+    git -C "$workspace" branch "$main_branch" "origin/$main_branch"
+  fi
+
+  git -C "$workspace" symbolic-ref HEAD refs/heads/__bare_placeholder__
+
+  echo "Creating primary worktree at '$workspace/$main_branch'..."
+  git -C "$workspace" worktree add "$workspace/$main_branch" "$main_branch"
+
+  set_branch_tracking_if_remote_exists "$workspace" "$main_branch"
+
+  echo "Restoring previous checkout contents into '$main_branch/'..."
+  restore_backup_into_main "$backup_dir" "$workspace/$main_branch"
+
+  echo "Standard checkout upgraded to bare workspace format."
+}
+
+upgrade_worktrees_layout_to_root() {
+  local workspace="$1"
+
+  if [[ ! -d "$workspace/.bare" ]] || ! is_git_pointer_file "$workspace"; then
+    echo "Error: '$workspace' is not a bare workspace (.bare + .git pointer file required)." >&2
+    exit 1
+  fi
+
+  if [[ ! -d "$workspace/worktrees" ]]; then
+    echo "Workspace already appears to use root-level worktrees (no worktrees/ directory found)."
+    rewrite_root_symlinks_from_worktrees_prefix "$workspace"
+    return
+  fi
+
+  shopt -s dotglob nullglob
+  local entries=("$workspace/worktrees"/*)
+  shopt -u dotglob nullglob
+
+  if (( ${#entries[@]} == 0 )); then
+    rmdir "$workspace/worktrees" 2>/dev/null || true
+    echo "Found empty worktrees/ directory; removed."
+    rewrite_root_symlinks_from_worktrees_prefix "$workspace"
+    return
+  fi
+
+  echo "Moving worktrees/* entries to workspace root..."
+  local moved=0
+  local src
+  for src in "${entries[@]}"; do
+    local name dest
+    name="$(basename "$src")"
+    dest="$workspace/$name"
+
+    if [[ -e "$dest" || -L "$dest" ]]; then
+      echo "Error: destination already exists: $dest" >&2
+      echo "Resolve conflicts, then rerun --upgrade." >&2
+      exit 1
+    fi
+
+    mv "$src" "$dest"
+    echo "  moved: worktrees/$name -> $name"
+    moved=$((moved + 1))
+  done
+
+  rmdir "$workspace/worktrees" 2>/dev/null || true
+  rewrite_root_symlinks_from_worktrees_prefix "$workspace"
+
+  echo "Moved $moved worktree directory(ies) to workspace root."
+}
+
+run_upgrade_mode() {
+  local workspace="$1"
+  local main_branch="$2"
+
+  if [[ ! -d "$workspace" ]]; then
+    echo "Error: workspace '$workspace' does not exist." >&2
+    exit 1
+  fi
+
+  require_outside_workspace "$workspace"
+
+  if [[ -d "$workspace/.git" ]]; then
+    upgrade_standard_checkout_in_place "$workspace" "$main_branch"
+  else
+    upgrade_worktrees_layout_to_root "$workspace"
+  fi
+
+  echo ""
+  echo "Upgrade complete."
+  echo ""
+  echo "Recommended Worktrunk setting:"
+  echo "  worktree-path = \"{{ branch | sanitize }}\""
+}
+
+run_fresh_setup_mode() {
+  local repo_url="$1"
+  local target_dir="$2"
+  local env_source="$3"
+  local main_branch="$4"
+
+  if [[ -d "$target_dir" ]]; then
+    echo "Error: $target_dir already exists. Remove it first or choose a different path." >&2
+    exit 1
+  fi
+
+  echo "Creating bare repo at $target_dir..."
+  mkdir -p "$target_dir"
+  cd "$target_dir"
+
+  git clone --bare --single-branch "$repo_url" .bare
+  echo "gitdir: ./.bare" > .git
+
+  configure_bare_workspace "$target_dir"
+
+  echo "Fetching all remote branches..."
+  git fetch --all --quiet
+
+  # Detach HEAD so worktree creation doesn't fail with "already used"
+  git symbolic-ref HEAD refs/heads/__bare_placeholder__
+
+  echo "Creating '$main_branch' worktree..."
+  git worktree add "$main_branch" "$main_branch"
+  set_branch_tracking_if_remote_exists "$target_dir" "$main_branch"
+
+  local workspace main_dir
+  workspace="$(pwd)"
+  main_dir="$workspace/$main_branch"
+
+  if [[ -n "$env_source" ]]; then
+    if [[ ! -d "$env_source" ]]; then
+      echo "Warning: source '$env_source' does not exist, skipping env copy." >&2
+    else
+      echo "Discovering .env files in $env_source..."
+
+      while IFS= read -r envfile; do
+        relpath="${envfile#$env_source/}"
+        if git -C "$env_source" ls-files --error-unmatch "$relpath" &>/dev/null; then
+          echo "  Skipping (tracked by git): $relpath"
+          continue
+        fi
+
+        destfile="$main_dir/$relpath"
+        mkdir -p "$(dirname "$destfile")"
+        cp "$envfile" "$destfile"
+        echo "  Copied to $main_branch/: $relpath"
+
+      done < <(find "$env_source" \
+          -not -path "*/node_modules/*" \
+          -not -path "*/.git/*" \
+          -not -path "*/.bare/*" \
+          -not -path "*/.next/*" \
+          -not -path "*/dist/*" \
+          -not -path "*/build/*" \
+          -not -path "*/.dist/*" \
+          -not -path "*/__pycache__/*" \
+          -not -path "*/.venv/*" \
+          \( -name ".env" -o -name ".env.*" -o -name ".envrc" \) \
+          | sort)
+    fi
+  fi
+
+  if [[ -d "$workspace/.letta" && ! -L "$workspace/.letta" ]]; then
+    if [[ -L "$main_dir/.letta" ]]; then
+      rm "$main_dir/.letta"
+    fi
+    mv "$workspace/.letta" "$main_dir/.letta"
+    echo "Moved .letta/ into $main_branch/"
+  fi
+
+  local install_cmd=""
+  if [[ -f "$main_dir/pnpm-lock.yaml" ]]; then
+    install_cmd="pnpm install"
+  elif [[ -f "$main_dir/bun.lockb" || -f "$main_dir/bun.lock" ]]; then
+    install_cmd="bun install"
+  elif [[ -f "$main_dir/yarn.lock" ]]; then
+    install_cmd="yarn install"
+  elif [[ -f "$main_dir/package.json" ]]; then
+    install_cmd="npm install"
+  elif [[ -f "$main_dir/pyproject.toml" ]]; then
+    install_cmd="uv sync"
+  elif [[ -f "$main_dir/requirements.txt" ]]; then
+    install_cmd="pip install -r requirements.txt"
+  elif [[ -f "$main_dir/Cargo.toml" ]]; then
+    install_cmd="cargo build"
+  fi
+
+  echo ""
+  echo "Bare repo worktree setup complete!"
+  echo ""
+  echo "  Workspace root:  $target_dir"
+  echo "  Main worktree:   $target_dir/$main_branch (source of truth)"
+  echo "  Git data:        $target_dir/.bare"
+  echo ""
+  echo "Next steps:"
+  if [[ -n "$install_cmd" ]]; then
+    echo "  cd $target_dir/$main_branch && $install_cmd"
+  else
+    echo "  cd $target_dir/$main_branch"
+  fi
+  echo ""
+  echo "To share .env files across worktrees:"
+  echo "  1. Add files to main/.worktreeinclude (e.g., .env, .envrc)"
+  echo "  2. Run 'wt step copy-ignored' after creating a new worktree"
+  echo ""
+  echo "To create a feature worktree:"
+  echo "  cd $target_dir/$main_branch && wt switch --create feat/my-feature"
+}
+
+# ── Parse arguments ───────────────────────────────────────────────────────────
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+MODE="fresh"
+REPO_URL=""
+TARGET_DIR=""
+UPGRADE_DIR=""
+ENV_SOURCE=""
+MAIN_BRANCH=""
+MAIN_BRANCH_SET=false
+
+if [[ "$1" == "--upgrade" ]]; then
+  MODE="upgrade"
+  UPGRADE_DIR="${2:-}"
+  if [[ -z "$UPGRADE_DIR" ]]; then
+    echo "Error: --upgrade requires a workspace path." >&2
+    usage
+    exit 1
+  fi
+  shift 2
+else
+  REPO_URL="${1:-}"
+  TARGET_DIR="${2:-}"
+  if [[ -z "$REPO_URL" || -z "$TARGET_DIR" ]]; then
+    usage
+    exit 1
+  fi
+  shift 2
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --copy-from|--copy-envs-from|--move-env-from)
+      if [[ "$MODE" != "fresh" ]]; then
+        echo "Error: $1 is only supported in fresh setup mode." >&2
+        exit 1
+      fi
+      ENV_SOURCE="${2:?$1 requires a path}"
+      shift 2
+      ;;
+    --main-branch)
+      MAIN_BRANCH="${2:?--main-branch requires a branch name}"
+      MAIN_BRANCH_SET=true
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$MODE" == "upgrade" ]]; then
+  if [[ ! -d "$UPGRADE_DIR" ]]; then
+    echo "Error: workspace '$UPGRADE_DIR' does not exist." >&2
+    exit 1
+  fi
+
+  WORKSPACE_ABS="$(cd "$UPGRADE_DIR" && pwd)"
+  if [[ "$MAIN_BRANCH_SET" == false ]]; then
+    MAIN_BRANCH="$(detect_default_main_branch "$WORKSPACE_ABS")"
+  fi
+
+  run_upgrade_mode "$WORKSPACE_ABS" "$MAIN_BRANCH"
+else
+  if [[ "$MAIN_BRANCH_SET" == false ]]; then
+    MAIN_BRANCH="main"
+  fi
+
+  run_fresh_setup_mode "$REPO_URL" "$TARGET_DIR" "$ENV_SOURCE" "$MAIN_BRANCH"
+fi


### PR DESCRIPTION
## Add: development/git/bare-repo-workspaces skill

A comprehensive skill for managing Git worktrees using the bare repo pattern with Worktrunk (wt) tooling.

**Why:** The bare repo workspace pattern keeps all worktrees organized inside a single project folder - clean, self-contained, and easy to manage. This skill captures best practices and provides helper scripts for:
- Setting up new bare repo workspaces
- Diagnosing and fixing common issues (e.g., Antigravity compatibility)
- Daily workflow with Worktrunk hooks for .env propagation

**Source:** 
- Extensive hands-on experience with bare repo workspaces across multiple projects
- Discovered and fixed Antigravity compatibility issues caused by relative paths (`repositoryformatversion=1`, `extensions.relativeWorktrees`)
- Based on karpathy-guidelines patterns for surgical, well-documented changes

**Testing:** 
- Validated `doctor.sh` script across 11 bare repo workspaces
- Confirmed Antigravity compatibility after fixes
- Verified git operations (worktree list, status) continue to work

**Attribution:**
- Worktrunk tool: https://worktrunk.dev
- Original `setup-workspace.sh` from earlier skill iteration

This replaces the previous PR #49 (add/bare-repo-worktrees) with a renamed skill that better reflects its purpose and includes fixes for Antigravity compatibility.

👾 Generated with [Letta Code](https://letta.com)