### PR TITLE
Add Letta Code channel creation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Skills are organized into practical, flat categories:
 letta/                   # Letta product ecosystem
 ├── agent-development/   # Agent design and architecture
 ├── conversations/       # Conversation management
+├── creating-letta-code-channels/ # Letta Code channel/plugin development
 ├── fleet-management/    # Managing multiple agents
 ├── importing-chatgpt-memory/ # Review ChatGPT exports before writing Letta memory
 ├── letta-api-client/    # Building apps with Letta SDK (Python/TypeScript)
@@ -105,6 +106,7 @@ meta/                        # Skills about the skill system
 
 - **agent-development** - Comprehensive guide for designing and building Letta agents (architecture selection, memory design, model selection, tool configuration)
 - **conversations** - Managing agent conversations and message history
+- **creating-letta-code-channels** - Building and debugging Letta Code channel adapters and dynamic user channel plugins
 - **fleet-management** - Managing and orchestrating multiple Letta agents
 - **importing-chatgpt-memory** - Reviewing ChatGPT exports by rendering conversations into readable markdown before importing durable memory into Letta
 - **letta-api-client** - Building applications with the Letta API using the Python and TypeScript SDKs (agents, tools, memory, multi-user patterns)

--- a/letta/creating-letta-code-channels/SKILL.md
+++ b/letta/creating-letta-code-channels/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: creating-letta-code-channels
+description: Builds and debugs Letta Code channels, including first-party channel adapters and dynamic user channel plugins under ~/.letta/channels. Use when adding Telegram, WhatsApp, Bluesky, Slack, Discord, or custom channel support; testing channel routing, pairing, MessageChannel, runtime dependencies, or channel plugin manifests.
+license: MIT
+---
+
+# Creating Letta Code channels
+
+Use this when adding or debugging Letta Code channel support.
+
+## First choice
+
+- **User plugin** (`~/.letta/channels/<id>/`) for headless experiments, community plugins, and fast workflow tests.
+- **First-party channel** (`src/channels/<id>/`) when the channel needs bespoke Desktop UI, custom account snapshots, Slack/Discord-style auto-routing, rich protocol fields, or migration/compatibility shims.
+
+User plugins cannot shadow first-party ids: `telegram`, `slack`, and `discord` are ignored under `~/.letta/channels/`. Use ids like `telegram-test`, `whatsapp-community`, or `custom-chat`.
+
+## Core workflow
+
+1. Work in `~/letta/letta-code` or a worktree.
+2. Read `src/channels/README.md` on branches with dynamic plugins.
+3. For a user plugin, create:
+   - `~/.letta/channels/<id>/channel.json`
+   - `~/.letta/channels/<id>/plugin.mjs`
+   - `~/.letta/channels/<id>/accounts.json`
+4. Always implement `messageActions` if agents should reply via `MessageChannel`.
+5. Start with `dmPolicy: "pairing"` for testing, or `allowlist`/`open` for known headless deployments.
+6. Test all four legs:
+   - plugin discovery/import
+   - inbound `adapter.onMessage(msg)` to route/pairing
+   - routed channel notification reaches the agent
+   - outbound `MessageChannel` calls `messageActions.handleAction` → `adapter.sendMessage`
+7. Run targeted tests, then `bun run typecheck`, `bun run lint`, `bun run build`.
+
+## References
+
+Read only what is needed:
+
+- `references/user-plugins.md` — dynamic plugin manifest/account/runtime/headless flow and gotchas.
+- `references/first-party-channels.md` — first-party channel file cascade and safety checks.
+- `references/testing.md` — smoke-test checklist and commands.
+
+## Scaffold helper
+
+Use the bundled scaffold for a minimal user plugin skeleton. Replace `<path-to-this-skill>` with this skill directory path:
+
+```bash
+npx tsx <path-to-this-skill>/scripts/scaffold-user-channel-plugin.ts \
+  my-channel "My Channel" \
+  --runtime-package some-sdk@1.0.0 \
+  --runtime-module some-sdk
+```
+
+It creates `channel.json`, `plugin.mjs`, and `accounts.example.json`. Replace the TODO inbound/outbound implementation with the real SDK calls.
+
+## Hard lessons
+
+- `MessageChannel` silently feels broken if `plugin.messageActions` is missing. Every plugin that should reply needs `describeMessageTool()` and `handleAction()`.
+- For public channels, suppress tool approval/control prompts unless there is verified operator routing. Posting approval prompts publicly leaks tool input and invites forged `approve` replies.
+- User plugin runtime resolution must not count parent/dev `node_modules`. Runtime modules should resolve from explicit runtime dirs only.
+- Headless pairing is CLI-first: `letta channels pair --channel <id> --code <code> --agent <agent-id> --conversation <conversation-id>`.
+- Running listeners reload `pairing.yaml` and `routing.yaml` on the next inbound miss; restart only when adapter/account config itself changed.

--- a/letta/creating-letta-code-channels/references/first-party-channels.md
+++ b/letta/creating-letta-code-channels/references/first-party-channels.md
@@ -1,0 +1,57 @@
+# First-party Letta Code channels
+
+Use first-party channel work when the channel needs Desktop UI, rich snapshots, compatibility shims, or bespoke routing.
+
+## File cascade
+
+Adding a channel usually touches:
+
+- `src/channels/types.ts` — account/config types, channel id union.
+- `src/channels/pluginRegistry.ts` — metadata and dynamic import.
+- `src/channels/<channel>/plugin.ts` — `ChannelPlugin` export.
+- `src/channels/<channel>/adapter.ts` — start/stop/inbound/send behavior.
+- `src/channels/<channel>/messageActions.ts` — `MessageChannel` action surface.
+- `src/channels/<channel>/setup.ts` — CLI setup wizard if needed.
+- `src/channels/<channel>/runtime.ts` — runtime dependency helper if needed.
+- `src/channels/accounts.ts` — legacy/default account clone handling.
+- `src/channels/service.ts` — snapshots, create/update payloads.
+- `src/websocket/listener/client.ts` — snapshot serialization/mapping.
+- `src/types/protocol_v2.ts` — wire protocol account snapshots and create/update payloads.
+- `src/channels/registry.ts` — only if routing differs from generic pairing/route flow.
+- `src/channels/xml.ts` — channel-specific message formatting hints.
+- `src/tests/channels/*.test.ts` — targeted unit coverage.
+
+Adding a per-channel field cascades through account/config types, service snapshots, accounts clone/defaults, protocol v2, websocket mapping, adapter behavior, and tests.
+
+## Required plugin shape
+
+Every reply-capable channel plugin must expose `messageActions`:
+
+```ts
+export const myChannelPlugin: ChannelPlugin = {
+  metadata: { id: "my-channel", displayName: "My Channel", runtimePackages: [], runtimeModules: [] },
+  createAdapter(account) { return createMyAdapter(account as MyChannelAccount); },
+  runSetup() { return runMySetup(); },
+  messageActions: myMessageActions,
+};
+```
+
+Without `messageActions`, the shared `MessageChannel` tool returns `Channel "X" does not expose MessageChannel actions.` as a tool-result string. Agents often absorb that silently, making the channel look like it no-opped.
+
+Use `src/channels/telegram/messageActions.ts` as the canonical simple implementation.
+
+## Routing choices
+
+- Generic pairing route: unknown direct senders receive a pairing code, `routing.yaml` maps chat → agent/conversation.
+- Slack/Discord-style auto-routing: channel account has an agent binding; registry creates conversations automatically for DMs/threads.
+- Threaded channels: choose stable route keys carefully. `chatId` should usually be the stable conversation/root id; `threadId` should only vary when routes should split.
+
+## Public-channel safety
+
+Public posting channels must not relay tool approval/control prompts by default. Implement `handleControlRequestEvent` as a no-op or verified-operator path. Otherwise `sendDirectReply` fallback can publicly post tool name, command args, working directory, and an `approve` instruction.
+
+## Bluesky lessons
+
+- Do not use pagination cursor presence as a “has polled before” flag. Bluesky may omit cursors when there is no next page. Use a dedicated `hasCompletedInitialPoll` boolean.
+- App passwords cannot read/send DMs; Bluesky V1 only supports public notifications unless OAuth with `transition:chat.bsky` is added.
+- Public notification policy should be named as an inbound/public policy in UI, even if the shared field is `dmPolicy`.

--- a/letta/creating-letta-code-channels/references/testing.md
+++ b/letta/creating-letta-code-channels/references/testing.md
@@ -1,0 +1,62 @@
+# Channel testing checklist
+
+## Basic commands
+
+From the relevant `letta-code` worktree:
+
+```bash
+bun install
+bun dev channels status
+bun dev channels install <channel>
+bun dev server --channels <channel> --debug
+```
+
+For self-hosted/local desktop envs, `LETTA_BASE_URL` may point at `http://localhost:<port>`, causing the listener to skip Cloud environment registration. That is fine for local testing if the target agent exists on that local server.
+
+## User plugin smoke test
+
+1. Create `~/.letta/channels/<id>/channel.json`, `plugin.mjs`, and `accounts.json`.
+2. Install runtime deps:
+
+   ```bash
+   bun dev channels install <id>
+   ```
+
+3. Start listener:
+
+   ```bash
+   bun dev server --channels <id> --debug
+   ```
+
+4. Confirm plugin-specific startup log appears. If import fails, check `runtime/node_modules` and the user plugin `node_modules` symlink.
+5. Send a platform message.
+6. If pairing is enabled, redeem the code:
+
+   ```bash
+   bun dev channels pair --channel <id> --code <code> --agent <agent-id> --conversation <conversation-id>
+   ```
+
+7. Send another platform message. The conversation should receive a `<channel-notification>`.
+8. Reply with `MessageChannel` using the channel id and `chat_id` from the notification.
+
+## Verification
+
+Run targeted tests first, then broad checks:
+
+```bash
+bun test src/tests/channels/<channel-or-area>.test.ts
+bun run typecheck
+bun run lint
+bun run build
+```
+
+`letta-code` uses `bun:test`, not a package `test` script.
+
+## Debugging symptoms
+
+- **Plugin not discovered**: id mismatch between directory and `channel.json`, invalid id chars, or id shadows first-party channel.
+- **Install says already installed but imports fail**: runtime resolver counted dev `node_modules`; ensure runtime deps actually exist under `~/.letta/channels/<id>/runtime/node_modules` and symlink `~/.letta/channels/<id>/node_modules` to it.
+- **Inbound receives pairing code forever**: pairing was not redeemed for the same `accountId`/`senderId`, or listener cannot reload `pairing.yaml`.
+- **Inbound reaches agent but replies no-op**: missing `plugin.messageActions` or route lookup mismatch in `MessageChannel` args.
+- **Route lookup misses**: wrong `chatId`, wrong `accountId`, or unstable `threadId` choice.
+- **Cron lease error**: usually unrelated to channel runtime; another Letta Code process owns scheduler lease.

--- a/letta/creating-letta-code-channels/references/user-plugins.md
+++ b/letta/creating-letta-code-channels/references/user-plugins.md
@@ -1,0 +1,159 @@
+# Dynamic user channel plugins
+
+## Layout
+
+```text
+~/.letta/channels/<id>/
+  channel.json
+  plugin.mjs
+  accounts.json
+  pairing.yaml
+  routing.yaml
+  runtime/
+    package.json
+    node_modules/
+```
+
+`channel.json`:
+
+```json
+{
+  "id": "whatsapp-community",
+  "displayName": "WhatsApp Community",
+  "entry": "./plugin.mjs",
+  "runtimePackages": ["some-sdk@1.0.0"],
+  "runtimeModules": ["some-sdk"]
+}
+```
+
+Rules:
+- `id` must match the directory name.
+- Do not use first-party ids (`telegram`, `slack`, `discord`). The registry skips them.
+- `entry` is relative to the channel directory and must not escape it.
+- `runtimePackages` install to `runtime/` via `letta channels install <id>`.
+- User plugin bare imports usually need `~/.letta/channels/<id>/node_modules -> runtime/node_modules` symlink. Letta Code links this after installing user-plugin runtime dependencies.
+
+## Account shape
+
+User plugins should rely on `account.config`, not first-party fields.
+
+```json
+{
+  "accounts": [
+    {
+      "channel": "whatsapp-community",
+      "accountId": "main",
+      "displayName": "WhatsApp Community",
+      "enabled": true,
+      "dmPolicy": "pairing",
+      "allowedUsers": [],
+      "config": {
+        "token": "...",
+        "phoneNumberId": "..."
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+Custom accounts have no generic `binding` field. Routing lives in `routing.yaml`, created by pairing, `letta channels route add`, or direct file management.
+
+## Minimal plugin contract
+
+`plugin.mjs` exports `channelPlugin` or `default`:
+
+```js
+export const channelPlugin = {
+  metadata: {
+    id: "whatsapp-community",
+    displayName: "WhatsApp Community",
+    runtimePackages: ["some-sdk@1.0.0"],
+    runtimeModules: ["some-sdk"]
+  },
+
+  async createAdapter(account) {
+    let onMessageHandler = null;
+    let running = false;
+
+    return {
+      id: `whatsapp-community:${account.accountId}`,
+      channelId: "whatsapp-community",
+      accountId: account.accountId,
+      name: account.displayName ?? "WhatsApp Community",
+      async start() { running = true; },
+      async stop() { running = false; },
+      isRunning() { return running; },
+      async sendMessage(msg) { return { messageId: crypto.randomUUID() }; },
+      async sendDirectReply(chatId, text, options) {},
+      get onMessage() { return onMessageHandler; },
+      set onMessage(handler) { onMessageHandler = handler; }
+    };
+  },
+
+  messageActions: {
+    describeMessageTool() { return { actions: ["send"] }; },
+    async handleAction({ adapter, request, formatText }) {
+      if (request.action !== "send") return `Error: unsupported action ${request.action}`;
+      const formatted = formatText(request.message ?? "");
+      const result = await adapter.sendMessage({
+        channel: request.channel,
+        chatId: request.chatId,
+        text: formatted.text,
+        parseMode: formatted.parseMode,
+        replyToMessageId: request.replyToMessageId,
+        threadId: request.threadId
+      });
+      return `Message sent to ${request.channel} (message_id: ${result.messageId})`;
+    }
+  }
+};
+```
+
+Inbound messages must call `adapter.onMessage(msg)` with:
+
+```ts
+{
+  channel: string;
+  accountId?: string;
+  chatId: string;
+  senderId: string;
+  senderName?: string;
+  chatLabel?: string;
+  text: string;
+  timestamp: number;
+  messageId?: string;
+  threadId?: string | null;
+  chatType?: "direct" | "channel";
+  isMention?: boolean;
+  raw?: unknown;
+}
+```
+
+## Headless pairing
+
+User plugins are headless. Pair from CLI:
+
+```bash
+letta channels pair \
+  --channel <id> \
+  --code <code> \
+  --agent <agent-id> \
+  --conversation <conversation-id>
+```
+
+Or route statically:
+
+```bash
+letta channels route add \
+  --channel <id> \
+  --chat-id <platform-chat-id> \
+  --agent <agent-id> \
+  --conversation <conversation-id>
+```
+
+`dmPolicy` behavior:
+- `pairing`: unknown senders get a pairing code. Good for manual tests.
+- `allowlist`: only `allowedUsers` sender IDs pass. Good for known headless users.
+- `open`: everyone can reach routing lookup. Use with explicit routes or safe public channels.

--- a/letta/creating-letta-code-channels/scripts/scaffold-user-channel-plugin.ts
+++ b/letta/creating-letta-code-channels/scripts/scaffold-user-channel-plugin.ts
@@ -1,0 +1,112 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+function usage(): never {
+  console.error(
+    `Usage: npx tsx scaffold-user-channel-plugin.ts <id> <display-name> [--dir <channels-root>] [--runtime-package <pkg>] [--runtime-module <module>] [--force]`,
+  );
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const id = args[0];
+const displayName = args[1];
+if (!id || !displayName) usage();
+if (!/^[a-z0-9][a-z0-9_-]*$/.test(id)) {
+  throw new Error(`Invalid channel id: ${id}`);
+}
+if (["telegram", "slack", "discord"].includes(id)) {
+  throw new Error(`User plugins cannot shadow first-party channel id: ${id}`);
+}
+
+let channelsRoot = join(homedir(), ".letta", "channels");
+let runtimePackage = "";
+let runtimeModule = "";
+let force = false;
+for (let i = 2; i < args.length; i++) {
+  const arg = args[i];
+  const next = args[i + 1];
+  if (arg === "--dir" && next) {
+    channelsRoot = next;
+    i++;
+  } else if (arg === "--runtime-package" && next) {
+    runtimePackage = next;
+    i++;
+  } else if (arg === "--runtime-module" && next) {
+    runtimeModule = next;
+    i++;
+  } else if (arg === "--force") {
+    force = true;
+  } else {
+    usage();
+  }
+}
+
+if (runtimePackage && !runtimeModule) runtimeModule = runtimePackage.replace(/@[^/@]+$/, "");
+if (runtimeModule && !runtimePackage) runtimePackage = runtimeModule;
+
+const dir = resolve(channelsRoot, id);
+const outputFiles = [
+  join(dir, "channel.json"),
+  join(dir, "plugin.mjs"),
+  join(dir, "accounts.example.json"),
+];
+const existingFiles = outputFiles.filter((filePath) => existsSync(filePath));
+if (existingFiles.length > 0 && !force) {
+  throw new Error(
+    `Refusing to overwrite existing files: ${existingFiles.join(", ")}. Pass --force to overwrite.`,
+  );
+}
+mkdirSync(dir, { recursive: true });
+
+const runtimePackages = runtimePackage ? [runtimePackage] : [];
+const runtimeModules = runtimeModule ? [runtimeModule] : [];
+
+writeFileSync(
+  join(dir, "channel.json"),
+  `${JSON.stringify(
+    {
+      id,
+      displayName,
+      entry: "./plugin.mjs",
+      runtimePackages,
+      runtimeModules,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+writeFileSync(
+  join(dir, "accounts.example.json"),
+  `${JSON.stringify(
+    {
+      accounts: [
+        {
+          channel: id,
+          accountId: "main",
+          displayName,
+          enabled: true,
+          dmPolicy: "pairing",
+          allowedUsers: [],
+          config: {
+            token: "TODO",
+          },
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+writeFileSync(
+  join(dir, "plugin.mjs"),
+  `// ${displayName} dynamic channel plugin skeleton.\n// TODO: replace start/stop/inbound/sendMessage with the real platform SDK.\n\nimport { randomUUID } from "node:crypto";\n\nexport const channelPlugin = {\n  metadata: {\n    id: ${JSON.stringify(id)},\n    displayName: ${JSON.stringify(displayName)},\n    runtimePackages: ${JSON.stringify(runtimePackages)},\n    runtimeModules: ${JSON.stringify(runtimeModules)}\n  },\n\n  async createAdapter(account) {\n    let running = false;\n    let onMessageHandler = null;\n\n    return {\n      id: \`${id}:\${account.accountId}\`,\n      channelId: ${JSON.stringify(id)},\n      accountId: account.accountId,\n      name: account.displayName ?? ${JSON.stringify(displayName)},\n\n      async start() {\n        running = true;\n        console.log(\"[${id}] adapter running.\");\n      },\n\n      async stop() {\n        running = false;\n      },\n\n      isRunning() {\n        return running;\n      },\n\n      async sendMessage(msg) {\n        if (!running) throw new Error(\"[${id}] adapter not running.\");\n        // TODO: send msg.text to msg.chatId with the platform SDK.\n        console.log(\"[${id}] sendMessage\", { chatId: msg.chatId, text: msg.text });\n        return { messageId: randomUUID() };\n      },\n\n      async sendDirectReply(chatId, text, options) {\n        if (!running) return;\n        // TODO: send pairing/no-route messages directly to chatId.\n        console.log(\"[${id}] sendDirectReply\", { chatId, text, options });\n      },\n\n      get onMessage() {\n        return onMessageHandler;\n      },\n\n      set onMessage(handler) {\n        onMessageHandler = handler;\n      }\n    };\n  },\n\n  messageActions: {\n    describeMessageTool() {\n      return { actions: [\"send\"] };\n    },\n\n    async handleAction({ adapter, request, formatText }) {\n      if (request.action !== \"send\") {\n        return \`Error: Action \"\${request.action}\" is not supported on ${id}.\`;\n      }\n      const text = request.message?.trim();\n      if (!text) return \"Error: send requires message.\";\n\n      const formatted = formatText(text);\n      const result = await adapter.sendMessage({\n        channel: ${JSON.stringify(id)},\n        chatId: request.chatId,\n        text: formatted.text,\n        parseMode: formatted.parseMode,\n        replyToMessageId: request.replyToMessageId,\n        threadId: request.threadId\n      });\n      return \`Message sent to ${id} (message_id: \${result.messageId})\`;\n    }\n  }\n};\n\nexport default channelPlugin;\n`,
+);
+
+console.log(`Created ${id} channel plugin skeleton at ${dir}`);
+console.log("Next: copy accounts.example.json to accounts.json and fill config secrets.");


### PR DESCRIPTION
## Summary
- Add a Letta ecosystem skill for building first-party Letta Code channels and dynamic user channel plugins.
- Include references for user-plugin manifests, headless pairing/routing, first-party adapter cascades, public-channel safety, and testing.
- Add a scaffold script for minimal dynamic channel plugin skeletons.

> "Channels are where state learns to cross the room."

Written by Cameron ◯ Letta Code