### PR TITLE
Add: tools/analyzing-candidate-cvs

### DIFF
--- a/tools/analyzing-candidate-cvs/SKILL.md
+++ b/tools/analyzing-candidate-cvs/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: analyzing-candidate-cvs
+description: Analyzes candidate CVs/resumes against one or more job offers. Use when the user asks to screen resumes, compare candidates, prepare technical interviews, build hiring shortlists, analyze CV PDFs/DOCX files, or produce candidate evaluation matrices and recommendations.
+---
+
+# Analyzing Candidate CVs
+
+Use this skill to analyze a hiring campaign from job offer(s) and candidate resumes. Produce structured, evidence-based French or English outputs depending on the user's preference.
+
+## Core principles
+
+- Start from the job offer: extract criteria before reading CVs.
+- Separate candidates by job offer/campaign when multiple roles exist.
+- Treat CV evidence carefully: distinguish **attested**, **partial/indirect**, **absent**, and **not evaluable from CV**.
+- Do not invent experience. If a skill, location, seniority, or availability is not in the CV, mark it as non-evaluable or a point to confirm.
+- Avoid automatic elimination unless the user defines eliminatory criteria.
+- If candidates are already preselected for interview, optimize the output for **interview preparation**, not just screening.
+- Include role-specific interview questions to validate gaps and critical assumptions.
+
+## Recommended directory structure
+
+Prefer one directory per job offer/campaign:
+
+```text
+cv-analysis/
+├── role-a/
+│   ├── job-offer.pdf|docx|txt
+│   └── candidates/
+│       ├── candidate-1.pdf|docx
+│       └── candidate-2.pdf|docx
+└── role-b/
+    ├── job-offer.pdf|docx|txt
+    └── candidates/
+        └── ...
+```
+
+Create outputs under:
+
+```text
+cv-analysis/_extracted_text/
+cv-analysis/_reports/
+```
+
+## Workflow
+
+1. **Inventory files**
+   - List job offers and candidate files.
+   - Flag duplicates or ambiguous assignments.
+   - Ask the user how to handle duplicates, mixed roles, missing offers, or unclear CV ownership.
+
+2. **Extract text**
+   - Use `scripts/extract_documents.py` when possible.
+   - For scanned PDFs or poor extraction, use OCR tooling if available and clearly flag extraction uncertainty.
+
+3. **Build the evaluation grid from the job offer**
+   - Extract responsibilities, required skills, desired skills, experience, education, domain constraints, soft skills, and practical constraints.
+   - Propose weights before scoring unless the user already approved a grid.
+   - Suggested default weighting:
+     - Technical skills: 35%
+     - Practical know-how / delivery experience: 25%
+     - Soft skills / collaboration: 15%
+     - Background / seniority / domain fit: 25%
+
+4. **Validate assumptions with the user**
+   - Confirm weights, eliminatory criteria, language, desired depth, and whether the output is for triage or interview preparation.
+   - Add non-scored practical constraints such as location/onsite availability when relevant.
+
+5. **Analyze candidates**
+   - Use only one copy of duplicate CVs.
+   - Score each candidate against the approved grid.
+   - For every conclusion, ground it in CV evidence.
+   - Highlight transferable strengths separately from direct role fit.
+
+6. **Produce reports**
+   - Create one detailed report per role/campaign.
+   - Create an executive synthesis if there are multiple roles or many candidates.
+   - Include matrices, candidate fiches, recommendations, ranking/prioritization, and interview questions.
+
+7. **Quality check**
+   - Re-read the ranking for consistency with the evidence.
+   - Check that “not mentioned” is not treated as “false”.
+   - Check that strong candidates outside the exact role are identified as such, not dismissed generically.
+
+## Evaluation markers
+
+Use a compact legend in matrices:
+
+| Marker | Meaning |
+|---|---|
+| ✅ | Explicitly attested in CV |
+| ⚠️ or ⚡ | Partial, indirect, limited, or unclear evidence |
+| ❌ | Not present in CV |
+| ❓ | Not evaluable from CV / confirm in interview |
+
+## Output structure
+
+For each role, include:
+
+1. Campaign context and files analyzed
+2. Evaluation grid and weights
+3. Comparative matrix
+4. Candidate ranking / prioritization
+5. Detailed candidate fiches:
+   - Profile summary
+   - Evidence by criterion
+   - Strengths
+   - Gaps / points to clarify
+   - Practical constraints visible in CV
+   - Recommendation: Favorable / À approfondir / Défavorable (or equivalent in requested language)
+   - Personalized interview questions
+6. Cross-candidate observations
+7. Methodological caveats
+
+For a reusable report skeleton, see `references/report-template.md`.
+
+## Tooling notes
+
+- Use Python libraries such as `pdfplumber` for PDFs and `python-docx` for DOCX.
+- If installing dependencies, prefer a project virtual environment when available; otherwise explain the choice.
+- CV data is personal data: avoid copying reports outside the working directory unless requested, and do not commit CVs or reports to a repository without explicit user approval.

--- a/tools/analyzing-candidate-cvs/references/report-template.md
+++ b/tools/analyzing-candidate-cvs/references/report-template.md
@@ -1,0 +1,68 @@
+# Candidate Analysis Report Template
+
+```markdown
+# Analyse des candidatures — <Role / Campaign>
+
+**Date :** <date>  
+**Poste :** <role>  
+**Fiche de poste :** `<file>`  
+**Candidats analysés :** <count>  
+**Hypothèses :** <preselection, onsite constraints, language, scoring caveats>
+
+## 1. Grille d'évaluation
+
+| Domaine | Pondération | Critères |
+|---|---:|---|
+| Compétences techniques | 35% | ... |
+| Savoir-faire / delivery | 25% | ... |
+| Savoir-être / collaboration | 15% | ... |
+| Parcours / expérience | 25% | ... |
+
+Légende : ✅ attesté · ⚠️ partiel · ❌ absent · ❓ non évaluable.
+
+## 2. Matrice comparative
+
+| Critère | Candidat A | Candidat B | Candidat C |
+|---|---|---|---|
+| ... | ... | ... | ... |
+
+## 3. Classement et recommandations
+
+| Rang | Candidat | Recommandation | Justification courte |
+|---:|---|---|---|
+| 1 | ... | Favorable | ... |
+
+## 4. Fiches détaillées
+
+### <Candidate>
+
+**Profil résumé :** ...  
+**Recommandation :** Favorable / À approfondir / Défavorable
+
+#### Évaluation par critère
+
+| Critère | Évaluation | Éléments CV |
+|---|---|---|
+| ... | ✅/⚠️/❌/❓ | ... |
+
+#### Forces
+- ...
+
+#### Points à creuser
+- ...
+
+#### Questions d'entretien personnalisées
+1. ...
+2. ...
+3. ...
+
+## 5. Observations transversales
+
+- ...
+
+## 6. Caveats méthodologiques
+
+- Analyse fondée sur les CVs et fiches fournies.
+- Absence de mention dans un CV ≠ absence réelle de compétence.
+- Les recommandations aident à prioriser et préparer les entretiens, elles ne remplacent pas l'évaluation humaine.
+```

--- a/tools/analyzing-candidate-cvs/scripts/extract_documents.py
+++ b/tools/analyzing-candidate-cvs/scripts/extract_documents.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Extract text from PDF, DOCX, TXT, and Markdown files for CV analysis.
+
+Usage:
+  python extract_documents.py /path/to/cv-analysis
+  python extract_documents.py /path/to/cv-analysis --out /path/to/_extracted_text
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+SUPPORTED = {".pdf", ".docx", ".txt", ".md"}
+
+
+def extract_pdf(path: Path) -> str:
+    import pdfplumber
+
+    chunks: list[str] = []
+    with pdfplumber.open(str(path)) as pdf:
+        for i, page in enumerate(pdf.pages, 1):
+            text = page.extract_text(x_tolerance=1, y_tolerance=3) or ""
+            chunks.append(f"\n--- Page {i} ---\n{text}")
+    return "\n".join(chunks)
+
+
+def extract_docx(path: Path) -> str:
+    from docx import Document
+
+    doc = Document(str(path))
+    chunks: list[str] = []
+    for para in doc.paragraphs:
+        text = para.text.strip()
+        if text:
+            chunks.append(text)
+    for i, table in enumerate(doc.tables, 1):
+        chunks.append(f"\n--- Tableau {i} ---")
+        for row in table.rows:
+            cells = [cell.text.strip() for cell in row.cells]
+            chunks.append(" | ".join(cells))
+    return "\n".join(chunks)
+
+
+def extract_file(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".pdf":
+        return extract_pdf(path)
+    if suffix == ".docx":
+        return extract_docx(path)
+    if suffix in {".txt", ".md"}:
+        return path.read_text(encoding="utf-8", errors="replace")
+    raise ValueError(f"Unsupported file type: {path.suffix}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", type=Path, help="Hiring campaign root directory")
+    parser.add_argument("--out", type=Path, default=None, help="Output directory")
+    args = parser.parse_args()
+
+    root = args.root.expanduser().resolve()
+    out = (args.out or (root / "_extracted_text")).expanduser().resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    ignored_dirs = {"_extracted_text", "_reports", ".git", "node_modules"}
+    files = [
+        p for p in root.rglob("*")
+        if p.is_file()
+        and p.suffix.lower() in SUPPORTED
+        and out not in p.parents
+        and not (ignored_dirs & set(p.parts))
+    ]
+
+    for path in sorted(files):
+        rel = path.relative_to(root)
+        target = out / (str(rel).replace("/", "__") + ".txt")
+        try:
+            text = extract_file(path)
+            target.write_text(text, encoding="utf-8")
+            print(f"OK {rel} -> {target.name} ({len(text)} chars)")
+        except Exception as exc:
+            print(f"ERROR {rel}: {exc}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Add: tools/analyzing-candidate-cvs

Adds a skill for analyzing candidate CVs/resumes against one or more job offers. Produces structured, evidence-based evaluation reports in French or English.

**What:**
- `SKILL.md` — Full workflow: inventory files → extract text → build evaluation grid → validate assumptions → analyze candidates → produce reports → quality check
- `references/report-template.md` — Reusable report skeleton with evaluation grid, comparative matrix, candidate fiches, and interview questions
- `scripts/extract_documents.py` — Python script for extracting text from PDF, DOCX, TXT, and Markdown files

**Why:** Hiring campaigns often involve reviewing many CVs against job offers. This skill gives agents a rigorous, repeatable methodology: extract criteria from the job offer first, score candidates against an approved grid, ground every conclusion in CV evidence, and produce actionable reports optimized for either screening or interview preparation.

**Source:** Developed and validated through real hiring campaigns in a French government context (beta.gouv.fr incubator). The evaluation methodology, markers (✅ ⚠️ ❌ ❓), and report structure were iterated over multiple recruitment rounds.

**Testing:** Used in production for multiple hiring campaigns with 5–20+ candidates per role. The extract script handles PDFs (via pdfplumber), DOCX (via python-docx), and plain text. The report template produces consistent, reviewable outputs.

**Attribution:** Developed by @kaaloo for internal use, contributed to the community.