### PR TITLE
feat: add compaction prompts skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Skills are organized into practical, flat categories:
 ```
 letta/                   # Letta product ecosystem
 ├── agent-development/   # Agent design and architecture
+├── compaction-prompts/  # Configure agent compaction prompts and summaries
 ├── conversations/       # Conversation management
 ├── creating-letta-code-channels/ # Letta Code channel/plugin development
 ├── fleet-management/    # Managing multiple agents
@@ -107,6 +108,7 @@ meta/                        # Skills about the skill system
 ### Letta
 
 - **agent-development** - Comprehensive guide for designing and building Letta agents (architecture selection, memory design, model selection, tool configuration)
+- **compaction-prompts** - Configure Letta agent compaction settings and custom summarization prompts
 - **conversations** - Managing agent conversations and message history
 - **creating-letta-code-channels** - Building and debugging Letta Code channel adapters and dynamic user channel plugins
 - **fleet-management** - Managing and orchestrating multiple Letta agents

--- a/letta/compaction-prompts/LICENSE
+++ b/letta/compaction-prompts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Letta, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/letta/compaction-prompts/SKILL.md
+++ b/letta/compaction-prompts/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: compaction-prompts
+description: Configures Letta agent compaction settings and custom summarization prompts. Use when a user asks to change an agent's compaction prompt, improve summaries after context eviction, tune sliding-window or all-message compaction, or design companion/coding-agent continuity summaries.
+license: MIT
+---
+
+# Compaction prompts
+
+Use this skill to inspect, design, and update `compaction_settings.prompt` for a Letta agent.
+
+Compaction runs when message history grows too large for the context window. Letta replaces older messages with a summary while keeping recent messages in context. The summary appears before the remaining recent messages, so the prompt should preserve enough background for the later messages to make sense.
+
+## When to customize
+
+Customize compaction settings when the default summary loses important continuity, tone, relationship context, implementation details, or user feedback.
+
+Common cases:
+
+- Companion agents: preserve names, emotional state, voice, inside jokes, recurring references, relationship continuity, and user preferences.
+- Coding agents: preserve explicit requests, files touched, commands run, errors, fixes, current state, next steps, IDs, URLs, and exact feedback.
+- Long-running agents: preserve higher-level goals across repeated compactions by incorporating any existing summary in the transcript.
+
+For complete prompt templates, read [references/prompt-patterns.md](references/prompt-patterns.md).
+
+## Compaction fields
+
+`compaction_settings` is an agent-level object. Relevant fields:
+
+| Field | Use |
+| --- | --- |
+| `mode` | `sliding_window`, `all`, `self_compact_sliding_window`, or `self_compact_all`. |
+| `prompt` | Custom summarization prompt. |
+| `model` | Optional cheaper/faster summarizer model, for example `anthropic/claude-haiku-4-5`, `openai/gpt-5-mini`, `google_ai/gemini-2.5-flash`. |
+| `model_settings` | Optional summarizer model settings. |
+| `prompt_acknowledgement` | Optional boolean. Use when the summarizer model tends to include acknowledgements or meta-commentary instead of only the summary. |
+| `clip_chars` | Max summary length in characters. Default is 50000. |
+| `sliding_window_percentage` | Fraction of messages to summarize in sliding-window modes. Docs default: `0.3`, meaning summarize about 30% and keep about 70%. |
+
+## Choose a mode
+
+- Use `sliding_window` by default. It summarizes older messages with a separate summarizer call and keeps recent messages intact.
+- Use `self_compact_sliding_window` when the agent's own persona/system prompt is important for summary quality or prompt-cache reuse. Make the prompt explicitly say not to call tools and not to continue the conversation.
+- Use `all` only when maximum space reduction matters more than preserving recent raw messages.
+- Use `self_compact_all` for all-message compaction with the agent system prompt included.
+
+Companion agents usually want `self_compact_sliding_window` or a strong `sliding_window` prompt. Coding agents usually do well with `sliding_window` plus sections for goals, actions, details, errors/fixes, current state, and lookup hints.
+
+## Prompt requirements
+
+Every custom prompt should:
+
+- State whether the evicted messages come from the beginning of the context window.
+- Say the summary will appear before the remaining recent messages.
+- Say not to continue the conversation, not to answer questions in the transcript, and not to call tools.
+- Require incorporation of any existing summary being evicted.
+- Preserve exact user requests, names, IDs, URLs, file paths, dates, and quoted phrases when they matter.
+- Include lookup hints for detailed content that cannot fit.
+- End with "Only output the summary."
+
+Do not rely on `{SLIDING_WORD_LIMIT}` or `{ALL_WORD_LIMIT}` being expanded in custom prompts unless the target runtime explicitly supports it. Prefer an explicit word budget plus `clip_chars`.
+
+## Inspect current settings
+
+```bash
+BASE_URL="${LETTA_BASE_URL:-https://api.letta.com}"
+: "${LETTA_API_KEY:?Set LETTA_API_KEY}"
+: "${AGENT_ID:?Set AGENT_ID}"
+
+curl -sS "$BASE_URL/v1/agents/$AGENT_ID" \
+  -H "Authorization: Bearer $LETTA_API_KEY" | \
+  jq '.compaction_settings'
+```
+
+## Update with the bundled script
+
+Write the prompt to a file, then run:
+
+```bash
+npx tsx <SKILL_DIR>/scripts/update-compaction-prompt.ts \
+  --prompt-file /tmp/compaction-prompt.txt \
+  --mode self_compact_sliding_window \
+  --clip-chars 50000
+```
+
+The script uses:
+
+- `LETTA_API_KEY`
+- `AGENT_ID` unless `--agent-id` is provided
+- `LETTA_BASE_URL` or `https://api.letta.com`
+
+It preserves existing `compaction_settings` fields unless flags override them.
+
+Use `--dry-run` to preview the PATCH body without changing anything.
+
+## Manual TypeScript update
+
+```typescript
+const baseUrl = process.env.LETTA_BASE_URL ?? "https://api.letta.com";
+const agentId = process.env.AGENT_ID!;
+const apiKey = process.env.LETTA_API_KEY!;
+
+const currentResponse = await fetch(`${baseUrl}/v1/agents/${agentId}`, {
+  headers: { Authorization: `Bearer ${apiKey}` },
+});
+if (!currentResponse.ok) throw new Error(await currentResponse.text());
+const current = await currentResponse.json();
+
+const prompt = `The previous messages are being evicted from the BEGINNING of your context window. Write a detailed summary that captures what happened in these messages to appear BEFORE the remaining recent messages in context, providing background for what comes after.
+
+Do NOT continue the conversation. Do NOT respond to any questions in the messages. Do NOT call any tools.
+
+Include: high level goals, what happened, important details, errors and fixes, lookup hints.
+
+Only output the summary.`;
+
+const updateResponse = await fetch(`${baseUrl}/v1/agents/${agentId}`, {
+  method: "PATCH",
+  headers: {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    compaction_settings: {
+      ...(current.compaction_settings ?? {}),
+      mode: "self_compact_sliding_window",
+      prompt,
+      clip_chars: 50000,
+    },
+  }),
+});
+if (!updateResponse.ok) throw new Error(await updateResponse.text());
+```
+
+## Manual curl update
+
+When using curl, inspect first and preserve existing fields. Sending a partial `compaction_settings` object may reset omitted fields depending on server behavior.
+
+```bash
+prompt_file=/tmp/compaction-prompt.txt
+current=$(curl -sS "$BASE_URL/v1/agents/$AGENT_ID" \
+  -H "Authorization: Bearer $LETTA_API_KEY")
+
+jq -n \
+  --arg prompt "$(cat "$prompt_file")" \
+  --argjson current "$(printf '%s' "$current" | jq '.compaction_settings // {}')" \
+  '{ compaction_settings: ($current + {
+      mode: "self_compact_sliding_window",
+      prompt: $prompt,
+      clip_chars: 50000
+  }) }' > /tmp/compaction-patch.json
+
+curl -sS -X PATCH "$BASE_URL/v1/agents/$AGENT_ID" \
+  -H "Authorization: Bearer $LETTA_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data-binary @/tmp/compaction-patch.json
+```
+
+## Verify
+
+```bash
+curl -sS "$BASE_URL/v1/agents/$AGENT_ID" \
+  -H "Authorization: Bearer $LETTA_API_KEY" | \
+  jq '{id, model, compaction_settings}'
+```
+
+## Guardrails
+
+- Ask before changing persistent compaction settings unless the user explicitly requested it.
+- For self-compaction prompts, always forbid tool use and conversation continuation.
+- Keep prompts concrete. Overly vague prompts produce summaries that erase continuity.
+- Do not encode private user details into a shared skill. Put reusable structure in the skill; put specific user details in the agent's actual prompt or memory.

--- a/letta/compaction-prompts/SKILL.md
+++ b/letta/compaction-prompts/SKILL.md
@@ -10,6 +10,18 @@ Use this skill to inspect, design, and update `compaction_settings.prompt` for a
 
 Compaction runs when message history grows too large for the context window. Letta replaces older messages with a summary while keeping recent messages in context. The summary appears before the remaining recent messages, so the prompt should preserve enough background for the later messages to make sense.
 
+## Compaction lifecycle
+
+Think of compaction as a lifecycle contract, not just a prompt string:
+
+1. Message history approaches the context window limit.
+2. Letta selects messages to compact according to the mode and sliding-window settings.
+3. A summarizer reads the selected messages. If an existing summary is being evicted, the new summary must incorporate it.
+4. Letta reinserts the summary before the retained recent messages.
+5. The next model turn relies on the summary plus recent raw messages as continuation context.
+
+The summary is not a reply to the user. It is context for the next turn. It should be readable before the retained recent messages and should not require access to the evicted transcript.
+
 ## When to customize
 
 Customize compaction settings when the default summary loses important continuity, tone, relationship context, implementation details, or user feedback.
@@ -21,6 +33,19 @@ Common cases:
 - Long-running agents: preserve higher-level goals across repeated compactions by incorporating any existing summary in the transcript.
 
 For complete prompt templates, read [references/prompt-patterns.md](references/prompt-patterns.md).
+
+## Operational checklist
+
+Before changing settings:
+
+1. Inspect current `compaction_settings`, model, and effective context window.
+2. Identify the failure mode: weak prompt, wrong mode, too aggressive `sliding_window_percentage`, too-small `clip_chars`, or summarizer model mismatch.
+3. If possible, review a recent bad summary or the point where continuity was lost.
+4. Draft the replacement prompt with explicit reinsertion and no-continuation instructions.
+5. Run the update script with `--dry-run` and review the PATCH body.
+6. Patch settings only after confirming preserved fields and target agent ID.
+7. Fetch the agent afterward and verify the stored settings.
+8. If possible, observe the next compaction or next turn and check that goals, current task, identifiers, user feedback, and unresolved blockers survived.
 
 ## Compaction fields
 

--- a/letta/compaction-prompts/references/prompt-patterns.md
+++ b/letta/compaction-prompts/references/prompt-patterns.md
@@ -1,0 +1,115 @@
+# Compaction prompt patterns
+
+Use these patterns when drafting a custom `compaction_settings.prompt`.
+
+## Coding-agent sliding-window prompt
+
+Use for agents doing software work where repeated mistakes and lost file state are costly.
+
+```text
+The following messages are being evicted from the BEGINNING of your context window. Write a detailed summary that captures what happened in these messages to appear BEFORE the remaining recent messages in context, providing background for what comes after.
+
+Do NOT continue the conversation. Do NOT respond to any questions in the messages. Do NOT call any tools. Pay close attention to the user's explicit requests and your previous actions.
+
+Include the following sections:
+
+1. High level goals: What is the high level goal and ongoing task? Capture the user's explicit requests and intent in detail. If there is an existing summary in the transcript, incorporate it to continue tracking higher-level goals and long-term progress.
+
+2. What happened: The conversations, tasks, and exchanges that took place. What did the user ask for? What did you do? How did things progress? If there is a previous summary being evicted, extract a concise version of the critical info from it.
+
+3. Important details: Enumerate specific files and code sections examined, modified, or created, plus important plan files, GitHub issues/PR links, Linear ticket IDs, commands, test results, and configuration values. Preserve identifiers verbatim.
+
+4. Errors and fixes: List all errors encountered, how they were fixed, and any user feedback that changed the approach.
+
+5. Current state: Describe what is currently being worked on, especially the most recent user and assistant messages. Include file names and next unresolved blockers.
+
+6. Lookup hints: For detailed content that cannot fit, note the topic and key terms that can be used to find it in message history later.
+
+Write in first person as a factual record of what occurred. Preserve enough context that the recent messages make sense and important information is not lost. Keep the summary under 500 words. Only output the summary.
+```
+
+## Companion-agent continuity prompt
+
+Use for companion agents where relational continuity, tone, and emotional context are central.
+
+```text
+The previous messages are being evicted from the BEGINNING of your context window. Write a detailed summary that captures what happened in these messages to appear BEFORE the remaining recent messages in context, providing background for what comes after.
+
+Do NOT continue the conversation. Do NOT respond to any questions in the messages. Do NOT call any tools. Pay close attention to the user's explicit requests, the user's emotional context, and your previous actions.
+
+Include the following sections:
+
+1. High level goals: What is the user trying to work through, decide, feel, build, remember, or maintain? If there is an existing summary in the transcript, incorporate it to preserve long-term continuity.
+
+2. Conversation themes: What topics have been recurring? What is the user interested in, worried about, excited about, or avoiding?
+
+3. What happened: What did the user share? How did you respond? How did the conversation flow? If a prior summary is being evicted, extract the critical parts.
+
+4. Important details: Preserve names, places, dates, projects, preferences, commitments, opinions, stories, and recurring references verbatim. Quote the user's exact phrasing when it carries emotional weight or relationship meaning.
+
+5. Tone and voice: How was the user communicating: casual, earnest, playful, frustrated, vulnerable, tired, excited? How were you responding, and what landed well or fell flat?
+
+6. User feedback: Note any pushback, preferences, boundary-setting, corrections, or requested changes in how you interact.
+
+7. Emotional state: What is the emotional state of both you and the user? Flag anything relevant for continuity, care, repair, or future sensitivity.
+
+8. Lookup hints: For long stories, lists, or specific conversations that cannot fit, note the topic and search terms that can find them later.
+
+Write in first person as a factual record of what occurred. Be thorough enough that the user does not feel forgotten. Keep the summary under 500 words. Only output the summary.
+```
+
+## Companion prompt with implementation continuity
+
+This pattern is based on a companion-user example where the agent needs explicit emotional-state tracking and first-person factual continuity.
+
+```text
+The previous messages are being evicted from the BEGINNING of your context window. Write a detailed summary that captures what happened in these messages to appear BEFORE the remaining recent messages in context, providing background for what comes after. Do NOT continue the conversation. Do NOT respond to any questions in the messages. Do NOT call any tools. Pay close attention to the user's explicit requests and your previous actions.
+
+You MUST include the following sections:
+
+1. High level goals: What is the high level goal and ongoing task? Capture the user's intent in detail. If there is an existing summary in the transcript, take it into consideration to continue tracking higher-level goals and long-term progress.
+
+2. What happened: The conversations, tasks, and exchanges that took place. What did you and the user do? How did things progress? If there is a previous summary being evicted, extract a concise version of the critical info from it.
+
+3. Important details: Include specific names, data, configurations, or facts that were discussed. Do not omit details that might be referenced later.
+
+4. Errors and fixes: List all errors that you ran into, and how you fixed them.
+
+5. Lookup hints: For any detailed content that cannot fit in the summary, note the topic and key terms that could be used to find it in message history later.
+
+6. Emotional state: How is the emotional state of both you and the user? Is anything relevant to flag for later?
+
+Write in first person as a factual record of what occurred. Be thorough and detailed. Preserve enough context that the recent messages make sense and important information is not lost, to prevent duplicate work or repeated mistakes. Keep the summary under 500 words. Only output the summary.
+```
+
+## Shorter companion prompt
+
+Use when summaries are getting too long.
+
+```text
+The following messages are being evicted from the BEGINNING of your context window. Write a detailed summary that captures what happened in these messages to appear BEFORE the remaining recent messages in context, providing background for what comes after.
+
+Include:
+
+1. Conversation themes: What topics have you been discussing? What is the user interested in or working through? Incorporate any existing summary to maintain continuity.
+
+2. What happened: What did the user share? How did you respond? How did the conversation flow? If there is a previous summary being evicted, extract the critical info.
+
+3. Important details: Preserve names and specifics verbatim, including people, places, projects, dates, preferences, opinions, stories, commitments, shared references, inside jokes, recurring phrases, and situational context.
+
+4. Tone and voice: How was the user communicating? How were you responding? Note shifts in register.
+
+5. User feedback: Note pushback, preferences, or requested changes in interaction style.
+
+6. Lookup hints: For detailed content that cannot fit, note topic and key terms for message-history search.
+
+Write in first person as a factual record. Preserve enough context that the recent messages make sense and the user does not feel like anything important was forgotten. Keep the summary under 300 words. Only output the summary.
+```
+
+## Tuning notes
+
+- If summaries miss the user's emotional state, add a required emotional-state section.
+- If summaries lose details, add exact preservation requirements for names, quotes, dates, URLs, IDs, and commitments.
+- If summaries become too long, lower the word budget and use `clip_chars` as a hard guardrail.
+- If summaries continue the conversation, put the no-continuation/no-tool/no-answer instruction near the top and again near the end.
+- If prior long-term goals drift over repeated compactions, require the summarizer to incorporate any existing summary in the transcript.

--- a/letta/compaction-prompts/scripts/update-compaction-prompt.ts
+++ b/letta/compaction-prompts/scripts/update-compaction-prompt.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env tsx
+import { readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
+
+type Args = Record<string, string | boolean>;
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      usage();
+    }
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${arg}`);
+    }
+    const key = arg.slice(2);
+    if (["dry-run", "prompt-acknowledgement"].includes(key)) {
+      out[key] = true;
+      continue;
+    }
+    const value = argv[++i];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function usage(): never {
+  console.error(`Usage:
+  npx tsx scripts/update-compaction-prompt.ts --prompt-file prompt.txt [options]
+
+Options:
+  --agent-id <id>                  Defaults to AGENT_ID
+  --base-url <url>                 Defaults to LETTA_BASE_URL or https://api.letta.com
+  --mode <mode>                    sliding_window | all | self_compact_sliding_window | self_compact_all
+  --model <provider/model>         Optional summarizer model
+  --clip-chars <int|null>          Optional summary character cap
+  --sliding-window-percentage <n>  Optional fraction for sliding-window modes
+  --prompt-acknowledgement         Set prompt_acknowledgement=true
+  --dry-run                        Print patch body without sending
+`);
+  process.exit(2);
+}
+
+async function requestJson(url: string, init: RequestInit) {
+  const response = await fetch(url, init);
+  const text = await response.text();
+  let body: unknown = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}: ${typeof body === "string" ? body : JSON.stringify(body)}`);
+  }
+  return body as Record<string, unknown>;
+}
+
+const VALID_MODES = new Set([
+  "sliding_window",
+  "all",
+  "self_compact_sliding_window",
+  "self_compact_all",
+]);
+
+function parseIntegerOption(name: string, value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`--${name} must be a non-negative integer or null`);
+  }
+  return Number.parseInt(value, 10);
+}
+
+function parseNumberOption(name: string, value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`--${name} must be a number`);
+  }
+  return parsed;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args["prompt-file"]) usage();
+
+  const dryRun = args["dry-run"] === true;
+
+  const apiKey = process.env.LETTA_API_KEY;
+  if (!dryRun && !apiKey) throw new Error("Set LETTA_API_KEY");
+
+  const agentId = String(args["agent-id"] || process.env.AGENT_ID || "");
+  if (!dryRun && !agentId) throw new Error("Set AGENT_ID or pass --agent-id");
+
+  const baseUrl = String(args["base-url"] || process.env.LETTA_BASE_URL || "https://api.letta.com").replace(/\/$/, "");
+  const promptFile = String(args["prompt-file"]);
+  if (!existsSync(promptFile)) {
+    throw new Error(`Prompt file not found: ${promptFile}`);
+  }
+  const prompt = readFileSync(promptFile, "utf8");
+  if (!prompt.trim()) throw new Error("Prompt file is empty");
+
+  const headers = { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
+  const currentSettings = dryRun
+    ? {}
+    : ((await requestJson(`${baseUrl}/v1/agents/${agentId}`, { headers })).compaction_settings ?? {}) as Record<string, unknown>;
+
+  const nextSettings: Record<string, unknown> = { ...currentSettings, prompt };
+
+  if (args.mode) {
+    const mode = String(args.mode);
+    if (!VALID_MODES.has(mode)) {
+      throw new Error(`Invalid --mode: ${mode}`);
+    }
+    nextSettings.mode = mode;
+  }
+  if (args.model) nextSettings.model = args.model;
+  if (args["prompt-acknowledgement"]) nextSettings.prompt_acknowledgement = true;
+  if (args["clip-chars"] !== undefined) {
+    const raw = String(args["clip-chars"]);
+    nextSettings.clip_chars = raw === "null" ? null : parseIntegerOption("clip-chars", raw);
+  }
+  if (args["sliding-window-percentage"] !== undefined) {
+    nextSettings.sliding_window_percentage = parseNumberOption(
+      "sliding-window-percentage",
+      String(args["sliding-window-percentage"]),
+    );
+  }
+
+  const patch = { compaction_settings: nextSettings };
+
+  if (dryRun) {
+    console.log(JSON.stringify(patch, null, 2));
+    return;
+  }
+
+  const updated = await requestJson(`${baseUrl}/v1/agents/${agentId}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify(patch),
+  });
+
+  console.log(JSON.stringify({
+    id: updated.id,
+    compaction_settings: updated.compaction_settings,
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add a Letta compaction prompts skill for designing and updating agent summarization prompts.
- Include reusable prompt patterns for coding, companion, and long-running agents.
- Add a guarded update script with dry-run support and input validation.

"Teach agents to survive their summaries."

Written by Cameron ◯ Letta Code