### PR TITLE
feat: add Letta Code channel creation skill

### DIFF
--- a/letta/creating-letta-code-channels/LICENSE
+++ b/letta/creating-letta-code-channels/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Letta, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/letta/creating-letta-code-channels/SKILL.md
+++ b/letta/creating-letta-code-channels/SKILL.md
@@ -1,62 +1,104 @@
 ---
 name: creating-letta-code-channels
-description: Builds and debugs Letta Code channels, including first-party channel adapters and dynamic user channel plugins under ~/.letta/channels. Use when adding Telegram, WhatsApp, Bluesky, Slack, Discord, or custom channel support; testing channel routing, pairing, MessageChannel, runtime dependencies, or channel plugin manifests.
+description: Builds, reviews, debugs, and tests Letta Code channels, including first-party adapters (Telegram, Slack, Discord, Custom) and dynamic user channel plugins under ~/.letta/channels. Use when adding channel support, changing account fields, channel routing, pairing, MessageChannel actions, media/transcription, runtime dependencies, listener behavior, desktop channel UI, or channel PR review.
 license: MIT
 ---
 
 # Creating Letta Code channels
 
-Use this when adding or debugging Letta Code channel support.
+Use this for work in a `letta-code` checkout involving channels: first-party adapters, dynamic user plugins, routing/pairing, `MessageChannel`, media attachments, channel account config, websocket protocol, and channel tests.
 
-## First choice
+## First move
 
-- **User plugin** (`~/.letta/channels/<id>/`) for headless experiments, community plugins, and fast workflow tests.
-- **First-party channel** (`src/channels/<id>/`) when the channel needs bespoke Desktop UI, custom account snapshots, Slack/Discord-style auto-routing, rich protocol fields, or migration/compatibility shims.
+1. Work in the target `letta-code` checkout or a worktree. If reviewing a PR, fetch the PR branch and inspect the actual diff against current `origin/main`.
+2. Identify the channel shape:
+   - **Dynamic user plugin** for headless/community experiments under `~/.letta/channels/<id>/`.
+   - **First-party channel** under `src/channels/<id>/` when it needs Desktop UI, rich typed snapshots, protocol fields, bespoke routing, runtime install support, or migration compatibility.
+3. Check whether the work changes one of these high-risk surfaces:
+   - Account/config fields.
+   - Routing semantics and route keys.
+   - `MessageChannel` outbound actions.
+   - Public-channel safety and control requests.
+   - Media download/transcription/image handling.
+   - Runtime dependency resolution.
+4. Read only the reference files needed for the surface:
+   - `references/architecture.md` — core channel architecture, route flow, account stores, registry behavior.
+   - `references/first-party-channels.md` — first-party file cascade and exact field-addition checklist.
+   - `references/user-plugins.md` — dynamic plugin manifest/account/runtime/headless flow.
+   - `references/message-actions.md` — `MessageChannel` wiring and common no-op failure mode.
+   - `references/routing-and-policies.md` — DM policy, account-bound routing, Slack/Discord threading, allowed channels.
+   - `references/media-and-transcription.md` — attachments, image base64, audio transcription, size limits.
+   - `references/testing.md` — targeted tests, smoke tests, debug symptoms.
 
-User plugins cannot shadow first-party ids: `telegram`, `slack`, and `discord` are ignored under `~/.letta/channels/`. Use ids like `telegram-test`, `whatsapp-community`, or `custom-chat`.
+## Non-negotiables
 
-## Core workflow
+- Always implement `messageActions` for any reply-capable channel. Without it, `MessageChannel` returns a string like `Channel "X" does not expose MessageChannel actions.` and agents often mistake that for success.
+- Never modify API message types. Use the protocol shapes as-is and add typed fields deliberately through the full cascade.
+- For public channels, do not post tool approval/control prompts publicly unless there is verified operator routing. A default `sendDirectReply` approval prompt can leak tool names, args, cwd, and approval instructions.
+- Adding a per-channel field is not a one-file change. Follow the cascade in `references/first-party-channels.md`.
+- Test the four legs of every channel: plugin discovery/import, inbound route/pairing, channel notification to the agent, outbound `MessageChannel` to the platform.
+- Use `bun:test`; there is no package `test` script. Run targeted tests first, then `bun run typecheck`, `bun run lint`, and usually `bun run build` before finalizing.
 
-1. Work in `~/letta/letta-code` or a worktree.
-2. Read `src/channels/README.md` on branches with dynamic plugins.
-3. For a user plugin, create:
-   - `~/.letta/channels/<id>/channel.json`
-   - `~/.letta/channels/<id>/plugin.mjs`
-   - `~/.letta/channels/<id>/accounts.json`
-4. Always implement `messageActions` if agents should reply via `MessageChannel`.
-5. Start with `dmPolicy: "pairing"` for testing, or `allowlist`/`open` for known headless deployments.
-6. Test all four legs:
-   - plugin discovery/import
-   - inbound `adapter.onMessage(msg)` to route/pairing
-   - routed channel notification reaches the agent
-   - outbound `MessageChannel` calls `messageActions.handleAction` → `adapter.sendMessage`
-7. Run targeted tests, then `bun run typecheck`, `bun run lint`, `bun run build`.
+## Channel type decision
 
-## References
+Use a **dynamic user plugin** when:
+- The channel is experimental, community-owned, or headless.
+- Desktop UI is not required.
+- Account state can live in `account.config`.
+- You can tolerate generic pairing/routes and CLI-first setup.
 
-Read only what is needed:
+Use a **first-party channel** when:
+- It needs Desktop setup/manage UI or typed top-level snapshots.
+- It needs special routing like Slack/Discord auto-routing or thread hydration.
+- It needs SDK/runtime dependency installation from the channel registry.
+- It needs custom media handling, voice transcription, reactions, uploads, or platform-specific reply formatting.
+- It must be supported as `telegram`, `slack`, `discord`, or another blessed channel id.
 
-- `references/user-plugins.md` — dynamic plugin manifest/account/runtime/headless flow and gotchas.
-- `references/first-party-channels.md` — first-party channel file cascade and safety checks.
-- `references/testing.md` — smoke-test checklist and commands.
+First-party ids cannot be shadowed by user plugins: `telegram`, `slack`, `discord`, and `custom` user plugin directories are ignored.
 
-## Scaffold helper
+## Core workflow for implementation
 
-Use the bundled scaffold for a minimal user plugin skeleton. Replace `<path-to-this-skill>` with this skill directory path:
+1. Read the relevant existing channel as the template:
+   - Telegram: simplest first-party channel, pairing-first, useful `messageActions` reference.
+   - Slack: account-bound routing, Socket Mode, debouncing, default permission mode.
+   - Discord: account-bound routing, guild/thread behavior, allowed channel gating, media download.
+2. Update types and account config before adapter behavior.
+3. Wire behavior in the adapter and registry.
+4. Wire `MessageChannel` action support.
+5. Add tests close to the behavior:
+   - Pure helper tests for gates, formatters, debounce keys, codecs.
+   - Service/protocol tests for account fields.
+   - Adapter tests for inbound/outbound behavior where mocking is practical.
+   - Registry tests for route creation/pairing behavior.
+6. Run targeted tests, typecheck, lint, and build.
+7. If pushing to someone else's PR branch with maintainer permissions, add a normal commit. Do not force-push or squash their branch unless explicitly asked.
+
+## Review workflow
+
+When reviewing a channel PR:
+
+1. Fetch the PR branch and diff against fresh `origin/main`, not stale local `main`.
+2. Inspect code paths, not just PR prose. PR bodies frequently omit cascade gaps.
+3. Check for these regressions:
+   - Existing accounts without new optional fields still behave the same.
+   - Defaulted fields are effective in snapshots, not `undefined` in UI-facing top-level fields.
+   - `false` and empty arrays survive partial updates where intended.
+   - Adapter gates do not prevent existing routed conversations from continuing unless that is explicit.
+   - Public/open modes cannot spam every visible channel when unbound.
+   - Reactions, attachments, and debounced messages do not bypass route/account safety.
+   - `MessageChannel` has `messageActions` and route lookup uses the same `chatId`/`threadId` keys emitted inbound.
+4. Run the new targeted tests. If touching TypeScript channel code, run `bun run typecheck` and `bun run lint`.
+5. In GitHub comments, follow the repository or user-requested comment footer convention. Do not add AI attribution unless explicitly required.
+
+## Scaffold helper for user plugins
+
+Use the bundled scaffold for a minimal dynamic plugin skeleton:
 
 ```bash
-npx tsx <path-to-this-skill>/scripts/scaffold-user-channel-plugin.ts \
+npx tsx <SKILL_DIR>/scripts/scaffold-user-channel-plugin.ts \
   my-channel "My Channel" \
   --runtime-package some-sdk@1.0.0 \
   --runtime-module some-sdk
 ```
 
-It creates `channel.json`, `plugin.mjs`, and `accounts.example.json`. Replace the TODO inbound/outbound implementation with the real SDK calls.
-
-## Hard lessons
-
-- `MessageChannel` silently feels broken if `plugin.messageActions` is missing. Every plugin that should reply needs `describeMessageTool()` and `handleAction()`.
-- For public channels, suppress tool approval/control prompts unless there is verified operator routing. Posting approval prompts publicly leaks tool input and invites forged `approve` replies.
-- User plugin runtime resolution must not count parent/dev `node_modules`. Runtime modules should resolve from explicit runtime dirs only.
-- Headless pairing is CLI-first: `letta channels pair --channel <id> --code <code> --agent <agent-id> --conversation <conversation-id>`.
-- Running listeners reload `pairing.yaml` and `routing.yaml` on the next inbound miss; restart only when adapter/account config itself changed.
+It creates `channel.json`, `plugin.mjs`, and `accounts.example.json`. Replace TODO inbound/outbound logic with real SDK calls. Then test discovery, install, pairing, inbound delivery, and `MessageChannel` replies.

--- a/letta/creating-letta-code-channels/references/architecture.md
+++ b/letta/creating-letta-code-channels/references/architecture.md
@@ -1,0 +1,98 @@
+# Letta Code channel architecture
+
+## Table of contents
+
+- Core objects
+- Lifecycle
+- Account stores
+- Inbound flow
+- Outbound flow
+- Route keys
+- Listener/runtime gotchas
+
+## Core objects
+
+Channels are platform adapters that bridge external messages into the agent turn queue and expose outbound actions through the shared `MessageChannel` tool.
+
+Important files:
+
+- `src/channels/types.ts` — shared account/config/message/adapter types.
+- `src/channels/plugin-types.ts` — `ChannelPlugin`, account patch, config patch, `messageActions` contracts.
+- `src/channels/plugin-registry.ts` — first-party and dynamic plugin discovery.
+- `src/channels/registry.ts` — adapter registry, pairing, auto-routing, route lookup, delivery buffering.
+- `src/channels/accounts.ts` — `accounts.json` load/save, clone, legacy migration.
+- `src/channels/routing.ts` — `routing.yaml` route store.
+- `src/channels/pairing.ts` — pairing code store.
+- `src/channels/service.ts` — desktop/websocket-facing account/config APIs and snapshots.
+- `src/tools/impl/message-channel.ts` — shared agent tool dispatching outbound actions.
+
+## Lifecycle
+
+`initializeChannels(channelNames)` loads channel accounts, creates adapters, registers them in `ChannelRegistry`, and starts them. The listener later installs the message handler and marks the registry ready. Before ready, inbound deliveries buffer.
+
+Adapters must expose:
+
+```ts
+{
+  id: `${channelId}:${accountId}`,
+  channelId,
+  accountId,
+  start(),
+  stop(),
+  isRunning(),
+  sendMessage(msg),
+  sendDirectReply(chatId, text, options?),
+  onMessage?: (msg) => Promise<void>,
+  prepareInboundMessage?(msg, { isFirstRouteTurn }),
+  handleControlRequestEvent?(event)
+}
+```
+
+`onMessage` is assigned by the registry. Platform SDK handlers should call it with an `InboundChannelMessage`.
+
+## Account stores
+
+First-party accounts live in `~/.letta/channels/<channel>/accounts.json` via `src/channels/accounts.ts`. Dynamic plugin accounts use the same store shape but put plugin-owned fields under `config`.
+
+Legacy configs are still parsed from older `config.json`-style files for some first-party channels. If adding a field, check both `accounts.ts` and `config.ts` for legacy/default handling.
+
+## Inbound flow
+
+1. Platform event arrives in adapter.
+2. Adapter filters bot/self messages, allowlists, mention policy, etc.
+3. Adapter downloads/normalizes media if needed.
+4. Adapter calls `adapter.onMessage(inbound)`.
+5. `ChannelRegistry.handleInboundMessage` checks pending control requests.
+6. Registry resolves account config.
+7. Registry either auto-routes (Slack/Discord style) or falls through to pairing/generic route lookup.
+8. Registry optionally calls `adapter.prepareInboundMessage` for first-route context hydration.
+9. Registry formats XML with `formatChannelNotification` and delivers/buffers it for the agent turn queue.
+
+## Outbound flow
+
+1. Agent calls `MessageChannel`.
+2. Tool resolves route/account from the current channel turn source or explicit args.
+3. Tool loads the channel plugin and calls `messageActions.handleAction`.
+4. `handleAction` validates the action and calls `adapter.sendMessage` or another adapter method.
+5. Adapter posts to platform and returns `{ messageId }` when possible.
+
+If `messageActions` is missing, `MessageChannel` does not throw. It returns a string result saying the channel exposes no actions. Treat this as a serious wiring bug.
+
+## Route keys
+
+A route is keyed by channel, account, `chatId`, and optional `threadId`.
+
+Choose these deliberately:
+
+- Direct chats: `chatId` is the platform DM/chat id, `threadId` null.
+- Slack threads: usually `chatId` channel id, `threadId` Slack thread timestamp.
+- Discord auto-created threads: `chatId` often becomes thread channel id, `threadId` thread channel id.
+- Discord parent-channel inline replies: `chatId` parent channel id, `threadId` null.
+
+Inbound and outbound must agree. If inbound emits one key but `MessageChannel` uses another, replies look like no-ops or route misses.
+
+## Listener/runtime gotchas
+
+- Running listeners reload `pairing.yaml` and `routing.yaml` on the next inbound miss; restart only when adapter/account config itself changed.
+- Listener/server mode differs from TUI for some hooks and secrets. Do not assume TUI-only initialization runs in listener mode.
+- Remote/self-hosted channel listener behavior may skip Cloud environment registration depending on `LETTA_BASE_URL`.

--- a/letta/creating-letta-code-channels/references/first-party-channels.md
+++ b/letta/creating-letta-code-channels/references/first-party-channels.md
@@ -1,57 +1,112 @@
 # First-party Letta Code channels
 
-Use first-party channel work when the channel needs Desktop UI, rich snapshots, compatibility shims, or bespoke routing.
+## Table of contents
 
-## File cascade
+- When to use first-party
+- New channel file cascade
+- Per-channel field cascade
+- Codec and protocol rules
+- Desktop UI cascade
+- Existing channel templates
+- Safety checks
 
-Adding a channel usually touches:
+## When to use first-party
 
-- `src/channels/types.ts` — account/config types, channel id union.
-- `src/channels/pluginRegistry.ts` — metadata and dynamic import.
+Use first-party channel work when the channel needs Desktop UI, rich typed snapshots, compatibility shims, SDK/runtime dependency install, special routing, or custom media/reaction behavior.
+
+Use dynamic plugins instead for headless/community integrations where generic account config and generic pairing/routes are enough.
+
+## New channel file cascade
+
+Adding a first-party channel usually touches:
+
+- `src/channels/types.ts` — channel id union, account/config types, type guards.
+- `src/channels/plugin-registry.ts` — metadata and dynamic import.
 - `src/channels/<channel>/plugin.ts` — `ChannelPlugin` export.
 - `src/channels/<channel>/adapter.ts` — start/stop/inbound/send behavior.
-- `src/channels/<channel>/messageActions.ts` — `MessageChannel` action surface.
+- `src/channels/<channel>/message-actions.ts` — `MessageChannel` action surface.
 - `src/channels/<channel>/setup.ts` — CLI setup wizard if needed.
 - `src/channels/<channel>/runtime.ts` — runtime dependency helper if needed.
-- `src/channels/accounts.ts` — legacy/default account clone handling.
-- `src/channels/service.ts` — snapshots, create/update payloads.
-- `src/websocket/listener/client.ts` — snapshot serialization/mapping.
-- `src/types/protocol_v2.ts` — wire protocol account snapshots and create/update payloads.
+- `src/channels/<channel>/account-config.ts` — plugin-owned config codec for websocket/desktop config payloads.
+- `src/channels/accounts.ts` — clone/default/legacy handling.
+- `src/channels/config.ts` — legacy config codec if legacy config exists.
+- `src/channels/service.ts` — snapshots, create/update, config APIs.
+- `src/websocket/listener/client.ts` — wire-to-service mappings if protocol fields are top-level.
+- `src/websocket/listener/protocol-inbound.ts` — validators for accepted protocol payloads.
+- `src/types/protocol_v2.ts` — wire protocol account snapshots and create/update payloads if typed there.
 - `src/channels/registry.ts` — only if routing differs from generic pairing/route flow.
-- `src/channels/xml.ts` — channel-specific message formatting hints.
-- `src/tests/channels/*.test.ts` — targeted unit coverage.
+- `src/channels/xml.ts` — channel-specific message formatting hints when needed.
+- `src/channels/*.test.ts` and `src/websocket/*.test.ts` — targeted coverage.
 
-Adding a per-channel field cascades through account/config types, service snapshots, accounts clone/defaults, protocol v2, websocket mapping, adapter behavior, and tests.
+## Per-channel field cascade
 
-## Required plugin shape
+Adding a per-channel field, such as Discord `allowedChannels`, `channelPolicy`, `autoThreadOnMention`, or `transcribeVoice`, usually touches:
 
-Every reply-capable channel plugin must expose `messageActions`:
+1. `src/channels/types.ts`.
+   - Add field to `<Channel>ChannelAccount`.
+   - Add field to `<Channel>ChannelConfig` if legacy/config snapshots need it.
+   - Add comments documenting defaults and whether DMs are affected.
+2. `src/channels/<channel>/account-config.ts`.
+   - Accept snake_case config field.
+   - Validate type strictly.
+   - Map to camelCase account patch.
+   - Serialize effective defaults in `toAccountConfig` and `toConfigSnapshotConfig`.
+3. `src/channels/plugin-types.ts`.
+   - Add to `ChannelPluginAccountPatch` if service create/update uses the generic patch type.
+4. `src/channels/service.ts`.
+   - Add to `ChannelConfigSnapshot` / `ChannelAccountSnapshot` if UI or protocol reads top-level field.
+   - Add to `toAccountSnapshot` and `getChannelConfigSnapshot`.
+   - Add to `createAccountFromPatch` and `mergeAccountPatch`.
+   - Add to `setChannelConfigLive` existing/create paths.
+   - Preserve explicit `false` with `??`, not `||`.
+5. `src/channels/accounts.ts`.
+   - Deep-copy arrays/objects in `cloneAccount`.
+   - Add legacy/default migration when applicable.
+6. `src/channels/config.ts`.
+   - Parse legacy snake_case config fields when applicable.
+7. Protocol/listener files.
+   - For first-party typed payloads, update `src/types/protocol_v2.ts`, `src/websocket/listener/client.ts`, and `src/websocket/listener/protocol-inbound.ts`.
+   - For nested plugin config payloads, account config adapters may handle validation, but still add protocol tests.
+8. Adapter behavior.
+   - Actually consume the field.
+   - Keep default behavior identical for accounts missing the new field.
+9. Tests.
+   - Codec tests.
+   - Service snapshot/create/update tests.
+   - Protocol validator/round-trip tests.
+   - Adapter or registry behavior tests.
 
-```ts
-export const myChannelPlugin: ChannelPlugin = {
-  metadata: { id: "my-channel", displayName: "My Channel", runtimePackages: [], runtimeModules: [] },
-  createAdapter(account) { return createMyAdapter(account as MyChannelAccount); },
-  runSetup() { return runMySetup(); },
-  messageActions: myMessageActions,
-};
-```
+## Codec and protocol rules
 
-Without `messageActions`, the shared `MessageChannel` tool returns `Channel "X" does not expose MessageChannel actions.` as a tool-result string. Agents often absorb that silently, making the channel look like it no-opped.
+- Wire/config fields are snake_case (`allowed_channels`, `transcribe_voice`).
+- In-memory TypeScript fields are camelCase (`allowedChannels`, `transcribeVoice`).
+- Strictly reject unknown first-party config keys unless the channel intentionally accepts arbitrary plugin config.
+- Serialize effective defaults in snapshots. Do not let UI-facing top-level fields drift as `undefined` when `config` says the default.
+- Partial updates must preserve unspecified fields. `false` and empty arrays can be meaningful.
 
-Use `src/channels/telegram/messageActions.ts` as the canonical simple implementation.
+## Desktop UI cascade
 
-## Routing choices
+Desktop channel UI lives in `letta-cloud`, not `letta-code`. For channel account field UI:
 
-- Generic pairing route: unknown direct senders receive a pairing code, `routing.yaml` maps chat → agent/conversation.
-- Slack/Discord-style auto-routing: channel account has an agent binding; registry creates conversations automatically for DMs/threads.
-- Threaded channels: choose stable route keys carefully. `chatId` should usually be the stable conversation/root id; `threadId` should only vary when routes should split.
+- `apps/code-desktop/ui/src/hooks/useChannels.ts` has channel snapshot unions and create/update payload unions.
+- Channel manage dialogs live under `apps/code-desktop/ui/src/app/pages/Channels/_components/{Channel}ManageDialog/`.
+- Hook companions live under `_hooks/use{Channel}ManageState.ts`.
+- Translations live at `apps/code-desktop/ui/src/translations/en.json` under `channels.{channel}SetupDialog`.
+- Multiline fields should use `RawTextArea` from `@letta-cloud/ui-component-library`.
+- Typecheck with `pnpm exec nx run code-desktop:type-check`.
 
-## Public-channel safety
+A `letta-code` backend field without desktop UI is acceptable for power-user JSON knobs, but document that explicitly.
 
-Public posting channels must not relay tool approval/control prompts by default. Implement `handleControlRequestEvent` as a no-op or verified-operator path. Otherwise `sendDirectReply` fallback can publicly post tool name, command args, working directory, and an `approve` instruction.
+## Existing channel templates
 
-## Bluesky lessons
+- Telegram: simplest first-party adapter, pairing-first, voice transcription, simple `messageActions`.
+- Slack: Socket Mode, account-bound auto-routing, debouncer, thread hydration, default permission mode.
+- Discord: gateway client, DMs + guild/thread routing, allowed channel gating, reactions, media downloads, auto-threading, delivery error replies.
 
-- Do not use pagination cursor presence as a “has polled before” flag. Bluesky may omit cursors when there is no next page. Use a dedicated `hasCompletedInitialPoll` boolean.
-- App passwords cannot read/send DMs; Bluesky V1 only supports public notifications unless OAuth with `transition:chat.bsky` is added.
-- Public notification policy should be named as an inbound/public policy in UI, even if the shared field is `dmPolicy`.
+## Safety checks
+
+- Public channels should not expose approval/control prompts to arbitrary users.
+- `open` policies should not create noisy unbound replies in every visible channel.
+- Mention gates should not block already-routed conversations unless explicit.
+- Gating should apply before expensive media downloads.
+- Attachments/reactions should not bypass allowed-channel or sender policy.

--- a/letta/creating-letta-code-channels/references/media-and-transcription.md
+++ b/letta/creating-letta-code-channels/references/media-and-transcription.md
@@ -1,0 +1,93 @@
+# Channel media and transcription
+
+## Table of contents
+
+- Attachment model
+- Download rules
+- Images and vision
+- Audio transcription
+- Telegram reference
+- Discord reference
+- Tests
+
+## Attachment model
+
+Inbound attachments use `ChannelMessageAttachment` in `src/channels/types.ts`:
+
+```ts
+{
+  id: string;
+  name?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  kind: "image" | "file" | "audio" | "video";
+  localPath?: string;
+  imageDataBase64?: string;
+  transcription?: string;
+}
+```
+
+XML formatting in `src/channels/xml.ts` includes attachment metadata and transcription when present.
+
+## Download rules
+
+Adapters should:
+
+- Enforce platform/file size limits before and after download.
+- Use timeouts/abort controllers.
+- Sanitize local filenames.
+- Store in temp directories, not repo paths.
+- Continue processing other attachments if one download fails.
+- Avoid downloading after a message fails gating/allowlist checks.
+
+## Images and vision
+
+Images should include `imageDataBase64` when small enough and supported. Telegram and Discord both inline image bytes for vision paths. Keep existing message content types from the API; do not mutate API message types.
+
+## Audio transcription
+
+Transcription uses `src/channels/transcription/index.ts` and OpenAI Whisper:
+
+- Requires `OPENAI_API_KEY`.
+- Uses `transcribeAudioFile(localPath)`.
+- Never throws; returns `{ success, text?, error? }`.
+- Should be opt-in per account via `transcribeVoice` / `transcribe_voice`.
+
+Do not call Whisper unless the account opt-in is enabled and `isTranscriptionConfigured()` is true.
+
+## Telegram reference
+
+Telegram has a distinct `voice` payload and `audio` payload. Existing behavior transcribes **voice memos only** when `transcribeVoice` is enabled. See:
+
+- `src/channels/telegram/media.ts`.
+- `src/channels/telegram/account-config.ts`.
+- `src/channels/telegram-adapter.test.ts`.
+- `src/channels/transcription.test.ts`.
+
+## Discord reference
+
+Discord voice messages arrive as ordinary audio attachments. There is no separate Telegram-style `voice` object. If supporting Discord transcription, apply opt-in transcription to inbound `audio/*` attachments.
+
+Wire the field through:
+
+- `DiscordChannelAccount` / `DiscordChannelConfig`.
+- `discord/account-config.ts` as `transcribe_voice`.
+- `config.ts` and `accounts.ts` for legacy/default parsing if needed.
+- `service.ts` snapshots and create/update merging.
+- Adapter attachment resolver params.
+- Media tests mocking both CDN download and Whisper endpoint.
+
+## Tests
+
+Useful tests:
+
+```bash
+bun test src/channels/transcription.test.ts
+bun test src/channels/telegram-adapter.test.ts
+bun test src/channels/discord-media.test.ts
+bun test src/channels/discord-channel-gating.test.ts
+bun test src/channels/discord-service.test.ts
+bun test src/websocket/listen-client-channel-accounts.test.ts
+```
+
+Mock `globalThis.fetch` for both platform download URL and `https://api.openai.com/v1/audio/transcriptions`. Restore `OPENAI_API_KEY` and `fetch` in `afterEach`.

--- a/letta/creating-letta-code-channels/references/message-actions.md
+++ b/letta/creating-letta-code-channels/references/message-actions.md
@@ -1,0 +1,98 @@
+# MessageChannel and channel message actions
+
+## Table of contents
+
+- Why messageActions matter
+- Minimal shape
+- Action design
+- Route and target resolution
+- Common failures
+- Tests
+
+## Why messageActions matter
+
+`MessageChannel` is the shared agent tool for outbound channel replies. It delegates channel-specific behavior to `plugin.messageActions`.
+
+If a plugin lacks `messageActions`, the tool returns a string result like:
+
+```text
+Channel "discord" does not expose MessageChannel actions.
+```
+
+Agents may not treat that as an exception. This is the most common reason inbound works but replies silently fail.
+
+## Minimal shape
+
+Use Telegram as the simple first-party reference. Dynamic plugins can use this shape:
+
+```js
+messageActions: {
+  describeMessageTool() {
+    return { actions: ["send"] };
+  },
+
+  async handleAction({ adapter, request, formatText }) {
+    if (request.action !== "send") {
+      return `Error: unsupported action ${request.action}`;
+    }
+    const formatted = formatText(request.message ?? "");
+    const result = await adapter.sendMessage({
+      channel: request.channel,
+      chatId: request.chatId,
+      threadId: request.threadId,
+      replyToMessageId: request.replyToMessageId,
+      text: formatted.text,
+      parseMode: formatted.parseMode,
+    });
+    return `Message sent to ${request.channel} (message_id: ${result.messageId})`;
+  },
+}
+```
+
+First-party channels should usually implement actions in `src/channels/<channel>/message-actions.ts` and export them from `plugin.ts`.
+
+## Action design
+
+Common actions:
+
+- `send` — text reply.
+- `react` — add/remove reaction.
+- `upload_file` / media action — upload attachment.
+- Channel-specific actions only when they are platform concepts agents should use.
+
+Keep action names stable. Tool descriptions should tell the agent which arguments matter for the current channel, especially `chatId`, `threadId`, `messageId`, and `replyToMessageId`.
+
+## Route and target resolution
+
+`MessageChannel` can infer the current channel/route from turn sources when the agent is replying to an inbound channel notification. Explicit args still need to match route keys.
+
+Check:
+
+- Inbound `chatId` matches outbound target `chatId`.
+- Inbound `threadId` is preserved when replies should stay threaded.
+- `accountId` is included for multi-account channels.
+- Direct replies vs normal messages use correct adapter methods.
+
+For Discord and Slack, thread handling is easy to break. Test top-level mentions, existing thread replies, and route-derived replies.
+
+## Common failures
+
+- Missing `messageActions`: tool returns no-action string.
+- Wrong `chatId`: route lookup misses.
+- Wrong `threadId`: reply posts to parent channel or cannot find route.
+- Adapter `sendMessage` ignores `replyToMessageId` or `threadId`.
+- Channel formatting escapes/mentions incorrectly.
+- Bot lacks platform permissions for threads, reactions, or uploads.
+
+## Tests
+
+Useful tests:
+
+```bash
+bun test src/channels/message-channel.test.ts
+bun test src/channels/<channel>-message-channel.test.ts
+bun test src/channels/message-tool-schema.test.ts
+bun test src/tests/tools/tool-execution-context.test.ts
+```
+
+Add route-specific tests for new channel actions, especially if adding custom schema contributions.

--- a/letta/creating-letta-code-channels/references/routing-and-policies.md
+++ b/letta/creating-letta-code-channels/references/routing-and-policies.md
@@ -1,0 +1,104 @@
+# Channel routing and policies
+
+## Table of contents
+
+- DM policies
+- Pairing flow
+- Auto-routing flow
+- Slack patterns
+- Discord patterns
+- Allowed channel gating
+- Open mode safety
+- Thread hydration
+
+## DM policies
+
+Shared `dmPolicy` values:
+
+- `pairing`: unknown users receive a pairing code. Operator approves via Desktop UI or CLI.
+- `allowlist`: only configured sender IDs can message.
+- `open`: anyone who can reach the bot can route, subject to account/channel behavior.
+
+Do not assume `dmPolicy` applies to public/guild/channel messages. Slack and Discord use additional channel-specific rules for guild/channel traffic.
+
+## Pairing flow
+
+Generic pairing flow:
+
+1. Unknown sender sends message.
+2. Registry creates pending pairing code.
+3. Adapter sends pairing instructions.
+4. Operator runs `letta channels pair --channel <id> --code <code> --agent <agent-id> --conversation <conversation-id>` or uses Desktop UI for first-party channels.
+5. Route is written to `routing.yaml`.
+6. Next message uses the route.
+
+User plugins are CLI-first. First-party channels may have Desktop UI.
+
+## Auto-routing flow
+
+Slack and Discord can bind an entire account/app/bot to an agent. Registry creates conversations automatically for DMs or channel interactions.
+
+Risks:
+
+- Missing `agentId` should not spam public channels.
+- Account-bound routes need stable summaries for new conversations.
+- Existing routes should continue even when the initial trigger condition is absent.
+
+## Slack patterns
+
+Slack channel behavior is `app_mention`-triggered by default. Replies are threaded using `thread_ts`. Slack has inbound debounce support and thread context hydration.
+
+When changing Slack routing, check:
+
+- `thread_ts` preservation.
+- `defaultPermissionMode` defaults.
+- Socket Mode event ack behavior.
+- Debounce key: account + channel + thread + sender.
+
+## Discord patterns
+
+Discord has two separate surfaces:
+
+- DMs: gated by `dmPolicy`.
+- Guild channels: gated by `channelPolicy`, mentions, threads, allowed channels, and account binding.
+
+Default Discord UX:
+
+1. Ignore normal guild channel chatter.
+2. User @mentions bot.
+3. Bot strips its mention and auto-creates a thread by default.
+4. Agent replies in that thread.
+5. Follow-up messages inside that thread route without more mentions.
+
+Important knobs:
+
+- `allowedChannels`: parent channel allowlist. Threads match on `parentId` when available.
+- `channelPolicy: "mention" | "open"`: whether non-mentioned guild messages are processed.
+- `autoThreadOnMention`: whether a new thread is created for top-level mentions.
+- `inboundDebounceMs`: optional trailing-edge message stacking.
+
+`autoThreadOnMention: false` with `channelPolicy: "mention"` keeps the first response inline, but follow-up parent-channel messages still need another @mention. That is expected unless route-aware adapter gating is implemented.
+
+## Allowed channel gating
+
+Apply allowed-channel gates before route creation and before expensive work like media downloads. For threads, compare the parent channel id when possible; fall back to the thread id only if parent is unavailable.
+
+Empty or undefined allowlist should preserve old behavior.
+
+## Open mode safety
+
+Open/public modes can be noisy. Guard these cases:
+
+- Unbound open-mode bots should not reply to every ambient channel message.
+- Public channels should not post internal control prompts.
+- `open` should usually be paired with an allowed channel allowlist.
+- Tests should cover unbound ambient traffic and explicit mentions separately.
+
+## Thread hydration
+
+Slack and Discord can hydrate first-route context for existing threads. This is context hydration, not replay:
+
+- Prior messages appear in `<thread-context>` / `<thread-history>`.
+- They are not delivered as separate turns.
+- Limits are bounded and usually text-only.
+- Hydration usually runs only on first route turn and only when `threadId` is present.

--- a/letta/creating-letta-code-channels/references/testing.md
+++ b/letta/creating-letta-code-channels/references/testing.md
@@ -1,50 +1,30 @@
 # Channel testing checklist
 
+## Table of contents
+
+- Basic commands
+- Targeted test map
+- User plugin smoke test
+- First-party smoke test
+- Discord smoke cases
+- Debugging symptoms
+- PR verification comment
+
 ## Basic commands
 
 From the relevant `letta-code` worktree:
 
 ```bash
 bun install
-bun dev channels status
-bun dev channels install <channel>
-bun dev server --channels <channel> --debug
+letta channels status
+letta channels install <channel>
+letta server --channels <channel> --debug
 ```
-
-For self-hosted/local desktop envs, `LETTA_BASE_URL` may point at `http://localhost:<port>`, causing the listener to skip Cloud environment registration. That is fine for local testing if the target agent exists on that local server.
-
-## User plugin smoke test
-
-1. Create `~/.letta/channels/<id>/channel.json`, `plugin.mjs`, and `accounts.json`.
-2. Install runtime deps:
-
-   ```bash
-   bun dev channels install <id>
-   ```
-
-3. Start listener:
-
-   ```bash
-   bun dev server --channels <id> --debug
-   ```
-
-4. Confirm plugin-specific startup log appears. If import fails, check `runtime/node_modules` and the user plugin `node_modules` symlink.
-5. Send a platform message.
-6. If pairing is enabled, redeem the code:
-
-   ```bash
-   bun dev channels pair --channel <id> --code <code> --agent <agent-id> --conversation <conversation-id>
-   ```
-
-7. Send another platform message. The conversation should receive a `<channel-notification>`.
-8. Reply with `MessageChannel` using the channel id and `chat_id` from the notification.
-
-## Verification
 
 Run targeted tests first, then broad checks:
 
 ```bash
-bun test src/tests/channels/<channel-or-area>.test.ts
+bun test src/channels/<channel-or-area>.test.ts
 bun run typecheck
 bun run lint
 bun run build
@@ -52,11 +32,90 @@ bun run build
 
 `letta-code` uses `bun:test`, not a package `test` script.
 
+## Targeted test map
+
+- Account/config codec: `src/tests/<channel>-account-config.test.ts`.
+- Protocol validators: `src/channels/<channel>-protocol.test.ts` and `src/websocket/listen-client-channel-accounts.test.ts`.
+- Service snapshots/create/update: `src/channels/<channel>-service.test.ts` or shared `service.test.ts`.
+- Adapter helpers: `src/channels/<channel>-adapter.test.ts` or focused helper tests.
+- Registry routing: `src/channels/<channel>-registry.test.ts` and shared `registry.test.ts`.
+- MessageChannel: `src/channels/<channel>-message-channel.test.ts`, `message-channel.test.ts`, `message-tool-schema.test.ts`.
+- Media/transcription: `src/channels/<channel>-media.test.ts`, `transcription.test.ts`.
+- Runtime deps/plugins: `runtimeDeps.test.ts`, `plugin-registry.test.ts`.
+
+## User plugin smoke test
+
+1. Create `~/.letta/channels/<id>/channel.json`, `plugin.mjs`, and `accounts.json`.
+2. Install runtime deps:
+
+   ```bash
+   letta channels install <id>
+   ```
+
+3. Start listener:
+
+   ```bash
+   letta server --channels <id> --debug
+   ```
+
+4. Confirm plugin-specific startup log appears. If import fails, check `runtime/node_modules` and the user plugin `node_modules` symlink.
+5. Send a platform message.
+6. If pairing is enabled, redeem the code:
+
+   ```bash
+   letta channels pair --channel <id> --code <code> --agent <agent-id> --conversation <conversation-id>
+   ```
+
+7. Send another platform message. The conversation should receive a `<channel-notification>`.
+8. Reply with `MessageChannel` using the channel id and `chat_id` from the notification.
+
+## First-party smoke test
+
+For first-party channels:
+
+1. Configure account with `letta channels configure <channel>` or edit account JSON if testing a power-user field.
+2. Start `letta server --channels <channel> --debug`.
+3. Trigger inbound from the platform.
+4. Verify route/pairing state in `~/.letta/channels/<channel>/routing.yaml` or `pairing.yaml`.
+5. Verify the agent receives `<channel-notification>` with correct text, sender, chat id, thread id, and attachment XML.
+6. Reply through `MessageChannel`.
+7. Verify platform reply location: DM, channel, thread, or reply target.
+
+## Discord smoke cases
+
+For Discord changes, cover:
+
+- DM pairing default.
+- DM `open` account-bound routing.
+- DM `allowlist` rejection.
+- Guild top-level @mention.
+- Auto-thread on mention true and false.
+- Existing thread follow-up without new mention.
+- `allowedChannels` parent-channel gating.
+- `channelPolicy: "open"` in an allowed test channel.
+- Unbound `channelPolicy: "open"` ambient message should not spam.
+- Reactions in tracked threads.
+- Audio/image attachments if media changed.
+
 ## Debugging symptoms
 
-- **Plugin not discovered**: id mismatch between directory and `channel.json`, invalid id chars, or id shadows first-party channel.
-- **Install says already installed but imports fail**: runtime resolver counted dev `node_modules`; ensure runtime deps actually exist under `~/.letta/channels/<id>/runtime/node_modules` and symlink `~/.letta/channels/<id>/node_modules` to it.
-- **Inbound receives pairing code forever**: pairing was not redeemed for the same `accountId`/`senderId`, or listener cannot reload `pairing.yaml`.
-- **Inbound reaches agent but replies no-op**: missing `plugin.messageActions` or route lookup mismatch in `MessageChannel` args.
-- **Route lookup misses**: wrong `chatId`, wrong `accountId`, or unstable `threadId` choice.
-- **Cron lease error**: usually unrelated to channel runtime; another Letta Code process owns scheduler lease.
+- Plugin not discovered: id mismatch between directory and `channel.json`, invalid id chars, or id shadows first-party channel.
+- Install says already installed but imports fail: runtime resolver counted dev `node_modules`; ensure runtime deps actually exist under `~/.letta/channels/<id>/runtime/node_modules` and symlink `~/.letta/channels/<id>/node_modules` to it.
+- Inbound receives pairing code forever: pairing was not redeemed for the same `accountId`/`senderId`, or listener cannot reload `pairing.yaml`.
+- Inbound reaches agent but replies no-op: missing `plugin.messageActions` or route lookup mismatch in `MessageChannel` args.
+- Route lookup misses: wrong `chatId`, wrong `accountId`, or unstable `threadId` choice.
+- Discord mentions work but follow-ups do not: adapter mention gate may be running before route-aware continuation, or follow-up is in parent channel with no thread and no mention.
+- Cron lease error: usually unrelated to channel runtime; another Letta Code process owns scheduler lease.
+
+## PR verification comment
+
+When commenting on a GitHub PR, include concise verification and follow the requested project or user footer convention:
+
+```markdown
+Verification:
+- `bun test ...` -> pass.
+- `bun run typecheck` -> clean.
+- `bun run lint` -> clean.
+```
+
+Do not include `Generated with Letta Code` or co-author attribution.

--- a/letta/creating-letta-code-channels/references/user-plugins.md
+++ b/letta/creating-letta-code-channels/references/user-plugins.md
@@ -1,5 +1,17 @@
 # Dynamic user channel plugins
 
+## Table of contents
+
+- Layout
+- channel.json
+- accounts.json
+- Minimal plugin contract
+- messageActions
+- Runtime dependencies
+- Headless pairing
+- Security
+- Debugging
+
 ## Layout
 
 ```text
@@ -14,7 +26,9 @@
     node_modules/
 ```
 
-`channel.json`:
+Use dynamic plugins for community/headless channels and fast experiments. Do not use first-party ids (`telegram`, `slack`, `discord`); the registry skips user plugins that shadow them.
+
+## channel.json
 
 ```json
 {
@@ -27,15 +41,16 @@
 ```
 
 Rules:
+
 - `id` must match the directory name.
-- Do not use first-party ids (`telegram`, `slack`, `discord`). The registry skips them.
 - `entry` is relative to the channel directory and must not escape it.
-- `runtimePackages` install to `runtime/` via `letta channels install <id>`.
-- User plugin bare imports usually need `~/.letta/channels/<id>/node_modules -> runtime/node_modules` symlink. Letta Code links this after installing user-plugin runtime dependencies.
+- `runtimePackages` install under `runtime/` via `letta channels install <id>`.
+- `runtimeModules` are what the plugin imports/checks.
+- Runtime resolution should not count parent/dev repo `node_modules`.
 
-## Account shape
+## accounts.json
 
-User plugins should rely on `account.config`, not first-party fields.
+Use `account.config` for plugin-owned settings:
 
 ```json
 {
@@ -127,13 +142,33 @@ Inbound messages must call `adapter.onMessage(msg)` with:
   threadId?: string | null;
   chatType?: "direct" | "channel";
   isMention?: boolean;
+  attachments?: ChannelMessageAttachment[];
+  reaction?: ChannelReactionEvent;
   raw?: unknown;
 }
 ```
 
+## messageActions
+
+Every reply-capable plugin needs `messageActions`. See `references/message-actions.md` for details. Without it, inbound can work while outbound silently fails.
+
+## Runtime dependencies
+
+Install runtime deps:
+
+```bash
+letta channels install <id>
+```
+
+Check:
+
+- Dependencies are under `~/.letta/channels/<id>/runtime/node_modules`.
+- User plugin import can resolve them, often through a `node_modules` symlink beside `plugin.mjs`.
+- The runtime resolver does not falsely pass because the monorepo has the dependency installed.
+
 ## Headless pairing
 
-User plugins are headless. Pair from CLI:
+Pair from CLI:
 
 ```bash
 letta channels pair \
@@ -154,6 +189,21 @@ letta channels route add \
 ```
 
 `dmPolicy` behavior:
+
 - `pairing`: unknown senders get a pairing code. Good for manual tests.
 - `allowlist`: only `allowedUsers` sender IDs pass. Good for known headless users.
 - `open`: everyone can reach routing lookup. Use with explicit routes or safe public channels.
+
+## Security
+
+- Do not expose tool approval/control prompts publicly.
+- Treat platform user IDs and channel IDs as untrusted input.
+- Avoid logging secrets from `account.config`.
+- Avoid dynamic imports outside the plugin directory and runtime dependency paths.
+
+## Debugging
+
+- Plugin not discovered: id mismatch, invalid id chars, bad `channel.json`, first-party id shadowing.
+- Install passes but import fails: runtime deps are not actually in the user plugin runtime path.
+- Pairing code repeats: pairing was redeemed for different `accountId`/sender or listener did not reload store.
+- Reply no-ops: missing `messageActions` or wrong route keys.

--- a/letta/creating-letta-code-channels/scripts/scaffold-user-channel-plugin.ts
+++ b/letta/creating-letta-code-channels/scripts/scaffold-user-channel-plugin.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, relative, resolve } from "node:path";
 
 function usage(): never {
   console.error(
@@ -16,11 +16,13 @@ if (!id || !displayName) usage();
 if (!/^[a-z0-9][a-z0-9_-]*$/.test(id)) {
   throw new Error(`Invalid channel id: ${id}`);
 }
-if (["telegram", "slack", "discord"].includes(id)) {
+const firstPartyChannelIds = new Set(["telegram", "slack", "discord", "custom"]);
+if (firstPartyChannelIds.has(id)) {
   throw new Error(`User plugins cannot shadow first-party channel id: ${id}`);
 }
 
-let channelsRoot = join(homedir(), ".letta", "channels");
+const home = homedir();
+let channelsRoot = join(home, ".letta", "channels");
 let runtimePackage = "";
 let runtimeModule = "";
 let force = false;
@@ -46,18 +48,27 @@ for (let i = 2; i < args.length; i++) {
 if (runtimePackage && !runtimeModule) runtimeModule = runtimePackage.replace(/@[^/@]+$/, "");
 if (runtimeModule && !runtimePackage) runtimePackage = runtimeModule;
 
-const dir = resolve(channelsRoot, id);
-const outputFiles = [
-  join(dir, "channel.json"),
-  join(dir, "plugin.mjs"),
-  join(dir, "accounts.example.json"),
-];
-const existingFiles = outputFiles.filter((filePath) => existsSync(filePath));
-if (existingFiles.length > 0 && !force) {
-  throw new Error(
-    `Refusing to overwrite existing files: ${existingFiles.join(", ")}. Pass --force to overwrite.`,
-  );
+channelsRoot = resolve(channelsRoot);
+const homeRelativeRoot = relative(home, channelsRoot);
+if (homeRelativeRoot.startsWith("..") || homeRelativeRoot === "") {
+  throw new Error(`Refusing to scaffold outside the home directory: ${channelsRoot}`);
 }
+
+const dir = resolve(channelsRoot, id);
+const rootRelativeDir = relative(channelsRoot, dir);
+if (rootRelativeDir.startsWith("..") || rootRelativeDir === "") {
+  throw new Error(`Invalid output directory: ${dir}`);
+}
+
+if (existsSync(dir) && !force) {
+  const existingEntries = readdirSync(dir);
+  if (existingEntries.length > 0) {
+    throw new Error(
+      `Refusing to overwrite existing channel directory: ${dir}. Pass --force to overwrite scaffold files.`,
+    );
+  }
+}
+
 mkdirSync(dir, { recursive: true });
 
 const runtimePackages = runtimePackage ? [runtimePackage] : [];
@@ -105,7 +116,7 @@ writeFileSync(
 
 writeFileSync(
   join(dir, "plugin.mjs"),
-  `// ${displayName} dynamic channel plugin skeleton.\n// TODO: replace start/stop/inbound/sendMessage with the real platform SDK.\n\nimport { randomUUID } from "node:crypto";\n\nexport const channelPlugin = {\n  metadata: {\n    id: ${JSON.stringify(id)},\n    displayName: ${JSON.stringify(displayName)},\n    runtimePackages: ${JSON.stringify(runtimePackages)},\n    runtimeModules: ${JSON.stringify(runtimeModules)}\n  },\n\n  async createAdapter(account) {\n    let running = false;\n    let onMessageHandler = null;\n\n    return {\n      id: \`${id}:\${account.accountId}\`,\n      channelId: ${JSON.stringify(id)},\n      accountId: account.accountId,\n      name: account.displayName ?? ${JSON.stringify(displayName)},\n\n      async start() {\n        running = true;\n        console.log(\"[${id}] adapter running.\");\n      },\n\n      async stop() {\n        running = false;\n      },\n\n      isRunning() {\n        return running;\n      },\n\n      async sendMessage(msg) {\n        if (!running) throw new Error(\"[${id}] adapter not running.\");\n        // TODO: send msg.text to msg.chatId with the platform SDK.\n        console.log(\"[${id}] sendMessage\", { chatId: msg.chatId, text: msg.text });\n        return { messageId: randomUUID() };\n      },\n\n      async sendDirectReply(chatId, text, options) {\n        if (!running) return;\n        // TODO: send pairing/no-route messages directly to chatId.\n        console.log(\"[${id}] sendDirectReply\", { chatId, text, options });\n      },\n\n      get onMessage() {\n        return onMessageHandler;\n      },\n\n      set onMessage(handler) {\n        onMessageHandler = handler;\n      }\n    };\n  },\n\n  messageActions: {\n    describeMessageTool() {\n      return { actions: [\"send\"] };\n    },\n\n    async handleAction({ adapter, request, formatText }) {\n      if (request.action !== \"send\") {\n        return \`Error: Action \"\${request.action}\" is not supported on ${id}.\`;\n      }\n      const text = request.message?.trim();\n      if (!text) return \"Error: send requires message.\";\n\n      const formatted = formatText(text);\n      const result = await adapter.sendMessage({\n        channel: ${JSON.stringify(id)},\n        chatId: request.chatId,\n        text: formatted.text,\n        parseMode: formatted.parseMode,\n        replyToMessageId: request.replyToMessageId,\n        threadId: request.threadId\n      });\n      return \`Message sent to ${id} (message_id: \${result.messageId})\`;\n    }\n  }\n};\n\nexport default channelPlugin;\n`,
+  `// ${displayName} dynamic channel plugin skeleton.\n// TODO: replace start/stop/inbound/sendMessage with the real platform SDK.\n\nexport const channelPlugin = {\n  metadata: {\n    id: ${JSON.stringify(id)},\n    displayName: ${JSON.stringify(displayName)},\n    runtimePackages: ${JSON.stringify(runtimePackages)},\n    runtimeModules: ${JSON.stringify(runtimeModules)}\n  },\n\n  async createAdapter(account) {\n    let running = false;\n    let onMessageHandler = null;\n\n    return {\n      id: \`${id}:\${account.accountId}\`,\n      channelId: ${JSON.stringify(id)},\n      accountId: account.accountId,\n      name: account.displayName ?? ${JSON.stringify(displayName)},\n\n      async start() {\n        running = true;\n        console.log(\"[${id}] adapter running.\");\n      },\n\n      async stop() {\n        running = false;\n      },\n\n      isRunning() {\n        return running;\n      },\n\n      async sendMessage(msg) {\n        if (!running) throw new Error(\"[${id}] adapter not running.\");\n        // TODO: send msg.text to msg.chatId with the platform SDK.\n        console.log(\"[${id}] sendMessage\", { chatId: msg.chatId, text: msg.text });\n        return { messageId: crypto.randomUUID() };\n      },\n\n      async sendDirectReply(chatId, text, options) {\n        if (!running) return;\n        // TODO: send pairing/no-route messages directly to chatId.\n        console.log(\"[${id}] sendDirectReply\", { chatId, text, options });\n      },\n\n      get onMessage() {\n        return onMessageHandler;\n      },\n\n      set onMessage(handler) {\n        onMessageHandler = handler;\n      }\n    };\n  },\n\n  messageActions: {\n    describeMessageTool() {\n      return { actions: [\"send\"] };\n    },\n\n    async handleAction({ adapter, request, formatText }) {\n      if (request.action !== \"send\") {\n        return \`Error: Action \"\${request.action}\" is not supported on ${id}.\`;\n      }\n      const text = request.message?.trim();\n      if (!text) return \"Error: send requires message.\";\n\n      const formatted = formatText(text);\n      const result = await adapter.sendMessage({\n        channel: ${JSON.stringify(id)},\n        chatId: request.chatId,\n        text: formatted.text,\n        parseMode: formatted.parseMode,\n        replyToMessageId: request.replyToMessageId,\n        threadId: request.threadId\n      });\n      return \`Message sent to ${id} (message_id: \${result.messageId})\`;\n    }\n  }\n};\n\nexport default channelPlugin;\n`,
 );
 
 console.log(`Created ${id} channel plugin skeleton at ${dir}`);


### PR DESCRIPTION
## Summary
- Add a Letta Code channel creation skill covering first-party adapters and dynamic user plugins.
- Include focused references for architecture, routing, MessageChannel actions, media/transcription, and testing.
- Add a safe user-plugin scaffold helper with first-party ID and overwrite guards.

"Channel work needs a map, not folklore."

Written by Cameron ◯ Letta Code