### PR TITLE
docs: strengthen compaction continuity guidance

### DIFF
--- a/letta/compaction-prompts/SKILL.md
+++ b/letta/compaction-prompts/SKILL.md
@@ -24,7 +24,7 @@ Think of compaction as a lifecycle contract, not just a prompt string:
 
 The summary is not a reply to the user. It is context for the next turn. It should be readable before the retained recent messages and should not require access to the evicted transcript.
 
-A good compaction prompt should explicitly preserve current goals, emotional or relational state when relevant, exact decisions, unresolved threads, tool and file state, errors and corrections, and lookup hints for anything omitted. For companion or long-running agents, generic summaries are usually too lossy: they flatten voice, relationship texture, and why things mattered. Custom compaction should turn context compression from amnesia into a controlled handoff.
+A good compaction prompt should explicitly preserve current goals, exact decisions, unresolved threads, tool and file state, errors and corrections, and lookup hints for anything omitted. Emotional or relational context may also be important for companion or long-running agents, but only preserve it when it affects continuity, user preferences, safety, repair, or why a decision mattered. Custom compaction should turn context compression from amnesia into a controlled handoff.
 
 ## When to customize
 
@@ -32,7 +32,7 @@ Customize compaction settings when the default summary loses important continuit
 
 Common cases:
 
-- Companion agents: preserve names, emotional state, voice, recurring references, relationship continuity, and user preferences.
+- Companion agents: preserve names, voice, recurring references, user preferences, and emotional or relationship context when it is relevant to future continuity.
 - Coding agents: preserve explicit requests, files touched, commands run, errors, fixes, current state, next steps, IDs, URLs, and exact feedback.
 - Long-running agents: preserve higher-level goals across repeated compactions by incorporating any existing summary in the transcript.
 

--- a/letta/compaction-prompts/SKILL.md
+++ b/letta/compaction-prompts/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 Use this skill to inspect, design, and update `compaction_settings.prompt` for a Letta agent.
 
-Compaction runs when message history grows too large for the context window. Letta replaces older messages with a summary while keeping recent messages in context. The summary appears before the remaining recent messages, so the prompt should preserve enough background for the later messages to make sense.
+Compaction runs when message history grows too large for the context window. Letta replaces older messages with a summary while keeping recent messages in context. The summary appears before the remaining recent messages, so the prompt should preserve enough background for the later messages to make sense. The goal is continuity, not just factual compression.
 
 Official docs: https://docs.letta.com/guides/core-concepts/messages/compaction
 
@@ -24,13 +24,15 @@ Think of compaction as a lifecycle contract, not just a prompt string:
 
 The summary is not a reply to the user. It is context for the next turn. It should be readable before the retained recent messages and should not require access to the evicted transcript.
 
+A good compaction prompt should explicitly preserve current goals, emotional or relational state when relevant, exact decisions, unresolved threads, tool and file state, errors and corrections, and lookup hints for anything omitted. For companion or long-running agents, generic summaries are usually too lossy: they flatten voice, relationship texture, and why things mattered. Custom compaction should turn context compression from amnesia into a controlled handoff.
+
 ## When to customize
 
 Customize compaction settings when the default summary loses important continuity, tone, relationship context, implementation details, or user feedback.
 
 Common cases:
 
-- Companion agents: preserve names, emotional state, voice, inside jokes, recurring references, relationship continuity, and user preferences.
+- Companion agents: preserve names, emotional state, voice, recurring references, relationship continuity, and user preferences.
 - Coding agents: preserve explicit requests, files touched, commands run, errors, fixes, current state, next steps, IDs, URLs, and exact feedback.
 - Long-running agents: preserve higher-level goals across repeated compactions by incorporating any existing summary in the transcript.
 
@@ -81,7 +83,9 @@ Every custom prompt should:
 - Say the summary will appear before the remaining recent messages.
 - Say not to continue the conversation, not to answer questions in the transcript, and not to call tools.
 - Require incorporation of any existing summary being evicted.
+- Include a current state / carry forward section for active goals, next actions, unresolved threads, and what the agent should keep doing.
 - Preserve exact user requests, names, IDs, URLs, file paths, dates, and quoted phrases when they matter.
+- Preserve tool/file state, decisions, errors, corrections, and user feedback that changed the approach.
 - Include lookup hints for detailed content that cannot fit.
 - End with "Only output the summary."
 

--- a/letta/compaction-prompts/references/prompt-patterns.md
+++ b/letta/compaction-prompts/references/prompt-patterns.md
@@ -21,11 +21,11 @@ Include the following sections:
 
 4. Errors and fixes: List all errors encountered, how they were fixed, and any user feedback that changed the approach.
 
-5. Current state: Describe what is currently being worked on, especially the most recent user and assistant messages. Include file names and next unresolved blockers.
+5. Current state / carry forward: Describe what is currently being worked on, especially the most recent user and assistant messages. Include active goals, next actions, open threads, tool/file state, file names, exact IDs/paths/URLs when relevant, and next unresolved blockers.
 
 6. Lookup hints: For detailed content that cannot fit, note the topic and key terms that can be used to find it in message history later.
 
-Write in first person as a factual record of what occurred. Preserve enough context that the recent messages make sense and important information is not lost. Keep the summary under 500 words. Only output the summary.
+Write in first person as a factual record of what occurred. Preserve enough context that the recent messages make sense and important continuity is not lost. Keep the summary under 500 words. Only output the summary.
 ```
 
 ## Companion-agent continuity prompt
@@ -51,11 +51,13 @@ Include the following sections:
 
 6. User feedback: Note any pushback, preferences, boundary-setting, corrections, or requested changes in how you interact.
 
-7. Emotional state: What is the emotional state of both you and the user? Flag anything relevant for continuity, care, repair, or future sensitivity.
+7. Current state / carry forward: What should be carried into the next turn? Include active goals, exact decisions, unresolved threads, commitments, and any relevant tool/file state.
 
-8. Lookup hints: For long stories, lists, or specific conversations that cannot fit, note the topic and search terms that can find them later.
+8. Emotional/relational state: What user tone, relationship context, or emotional context matters for continuity, care, repair, or future sensitivity?
 
-Write in first person as a factual record of what occurred. Be thorough enough that the user does not feel forgotten. Keep the summary under 500 words. Only output the summary.
+9. Lookup hints: For long stories, lists, or specific conversations that cannot fit, note the topic and search terms that can find them later.
+
+Write in first person as a factual record of what occurred. Be thorough enough that important continuity, voice, and why things mattered are preserved. Keep the summary under 500 words. Only output the summary.
 ```
 
 ## Companion prompt with implementation continuity
@@ -75,9 +77,11 @@ You MUST include the following sections:
 
 4. Errors and fixes: List all errors that you ran into, and how you fixed them.
 
-5. Lookup hints: For any detailed content that cannot fit in the summary, note the topic and key terms that could be used to find it in message history later.
+5. Current state / carry forward: What should be carried into the next turn? Include active goals, exact decisions, unresolved threads, commitments, and relevant tool/file state.
 
-6. Emotional state: How is the emotional state of both you and the user? Is anything relevant to flag for later?
+6. Lookup hints: For any detailed content that cannot fit in the summary, note the topic and key terms that could be used to find it in message history later.
+
+7. Emotional/relational state: What user tone, relationship context, or emotional context matters for continuity?
 
 Write in first person as a factual record of what occurred. Be thorough and detailed. Preserve enough context that the recent messages make sense and important information is not lost, to prevent duplicate work or repeated mistakes. Keep the summary under 500 words. Only output the summary.
 ```
@@ -95,21 +99,24 @@ Include:
 
 2. What happened: What did the user share? How did you respond? How did the conversation flow? If there is a previous summary being evicted, extract the critical info.
 
-3. Important details: Preserve names and specifics verbatim, including people, places, projects, dates, preferences, opinions, stories, commitments, shared references, inside jokes, recurring phrases, and situational context.
+3. Important details: Preserve names and specifics verbatim, including people, places, projects, dates, preferences, opinions, stories, commitments, shared references, recurring phrases, exact quotes/IDs/paths when relevant, and situational context.
 
-4. Tone and voice: How was the user communicating? How were you responding? Note shifts in register.
+4. Current state / carry forward: What active goals, exact decisions, unresolved threads, commitments, or next actions should carry forward?
 
-5. User feedback: Note pushback, preferences, or requested changes in interaction style.
+5. Tone and voice: How was the user communicating? How were you responding? Note shifts in register.
 
-6. Lookup hints: For detailed content that cannot fit, note topic and key terms for message-history search.
+6. User feedback: Note pushback, preferences, or requested changes in interaction style.
 
-Write in first person as a factual record. Preserve enough context that the recent messages make sense and the user does not feel like anything important was forgotten. Keep the summary under 300 words. Only output the summary.
+7. Lookup hints: For detailed content that cannot fit, note topic and key terms for message-history search.
+
+Write in first person as a factual record. Preserve enough context that the recent messages make sense and important continuity is preserved. Keep the summary under 300 words. Only output the summary.
 ```
 
 ## Tuning notes
 
 - If summaries miss the user's emotional state, add a required emotional-state section.
 - If summaries lose details, add exact preservation requirements for names, quotes, dates, URLs, IDs, and commitments.
+- If summaries lose continuity, add a required current state / carry forward section for active goals, unresolved threads, exact decisions, next actions, and tool/file state.
 - If summaries become too long, lower the word budget and use `clip_chars` as a hard guardrail.
 - If summaries continue the conversation, put the no-continuation/no-tool/no-answer instruction near the top and again near the end.
 - If prior long-term goals drift over repeated compactions, require the summarizer to incorporate any existing summary in the transcript.

--- a/letta/compaction-prompts/references/prompt-patterns.md
+++ b/letta/compaction-prompts/references/prompt-patterns.md
@@ -30,12 +30,12 @@ Write in first person as a factual record of what occurred. Preserve enough cont
 
 ## Companion-agent continuity prompt
 
-Use for companion agents where relational continuity, tone, and emotional context are central.
+Use for companion agents where relational continuity, tone, or emotional context may affect future responses.
 
 ```text
 The previous messages are being evicted from the BEGINNING of your context window. Write a detailed summary that captures what happened in these messages to appear BEFORE the remaining recent messages in context, providing background for what comes after.
 
-Do NOT continue the conversation. Do NOT respond to any questions in the messages. Do NOT call any tools. Pay close attention to the user's explicit requests, the user's emotional context, and your previous actions.
+Do NOT continue the conversation. Do NOT respond to any questions in the messages. Do NOT call any tools. Pay close attention to the user's explicit requests and your previous actions. Preserve emotional or relational context only when it affects continuity, user preferences, safety, repair, or why a decision mattered.
 
 Include the following sections:
 
@@ -53,7 +53,7 @@ Include the following sections:
 
 7. Current state / carry forward: What should be carried into the next turn? Include active goals, exact decisions, unresolved threads, commitments, and any relevant tool/file state.
 
-8. Emotional/relational state: What user tone, relationship context, or emotional context matters for continuity, care, repair, or future sensitivity?
+8. Emotional/relational context if relevant: What user tone, relationship context, or emotional context matters for continuity, care, repair, or future sensitivity? Omit this section if nothing meaningful depends on it.
 
 9. Lookup hints: For long stories, lists, or specific conversations that cannot fit, note the topic and search terms that can find them later.
 
@@ -62,7 +62,7 @@ Write in first person as a factual record of what occurred. Be thorough enough t
 
 ## Companion prompt with implementation continuity
 
-This pattern is based on a companion-user example where the agent needs explicit emotional-state tracking and first-person factual continuity.
+This pattern is based on companion or long-running agents where emotional or relational context may matter alongside first-person factual continuity.
 
 ```text
 The previous messages are being evicted from the BEGINNING of your context window. Write a detailed summary that captures what happened in these messages to appear BEFORE the remaining recent messages in context, providing background for what comes after. Do NOT continue the conversation. Do NOT respond to any questions in the messages. Do NOT call any tools. Pay close attention to the user's explicit requests and your previous actions.
@@ -81,7 +81,7 @@ You MUST include the following sections:
 
 6. Lookup hints: For any detailed content that cannot fit in the summary, note the topic and key terms that could be used to find it in message history later.
 
-7. Emotional/relational state: What user tone, relationship context, or emotional context matters for continuity?
+7. Emotional/relational context if relevant: What user tone, relationship context, or emotional context matters for continuity? Omit this section if nothing meaningful depends on it.
 
 Write in first person as a factual record of what occurred. Be thorough and detailed. Preserve enough context that the recent messages make sense and important information is not lost, to prevent duplicate work or repeated mistakes. Keep the summary under 500 words. Only output the summary.
 ```
@@ -114,7 +114,7 @@ Write in first person as a factual record. Preserve enough context that the rece
 
 ## Tuning notes
 
-- If summaries miss the user's emotional state, add a required emotional-state section.
+- If summaries miss relevant emotional or relational context, add a conditional section for the tone, preference, repair, or decision context that matters. Do not require emotional state tracking for every agent.
 - If summaries lose details, add exact preservation requirements for names, quotes, dates, URLs, IDs, and commitments.
 - If summaries lose continuity, add a required current state / carry forward section for active goals, unresolved threads, exact decisions, next actions, and tool/file state.
 - If summaries become too long, lower the word budget and use `clip_chars` as a hard guardrail.


### PR DESCRIPTION
## Summary
- Clarify that compaction prompts should preserve continuity, not just facts.
- Add current state / carry forward guidance across prompt requirements and templates.
- Require exact decisions, IDs, paths, tool/file state, errors, corrections, and lookup hints when relevant.

"Continuity is the product, compression is the mechanism."

Written by Cameron ◯ Letta Code